### PR TITLE
porting "unsorted" fixture to the builtin drned

### DIFF
--- a/drned/adm/conftest.py
+++ b/drned/adm/conftest.py
@@ -13,4 +13,5 @@ from drned.fixtures import op
 from drned.fixtures import pytest_addoption
 from drned.fixtures import pytest_generate_tests
 from drned.fixtures import root
+from drned.fixtures import unsorted
 from drned.fixtures import yangpath

--- a/drned/common/test_template.py
+++ b/drned/common/test_template.py
@@ -1,5 +1,4 @@
 from distutils.version import LooseVersion
-import drned
 import pytest
 import glob
 import os
@@ -91,7 +90,8 @@ def test_template_single(device, template, op):
         pytest.fail("The state after rollback differs from before load. " +
                     "Please check before-test.cfg and after-test.cfg")
 
-def test_template_set(device, init, fname, init_op, op, end_op):
+
+def test_template_set(device, init, fname, init_op, op, end_op, unsorted):
     """Normal test of template file set, defined by naming convention:
 
     first_set:0.txt
@@ -146,9 +146,9 @@ def test_template_set(device, init, fname, init_op, op, end_op):
     Returns:
         nothing
     """
-    _drned_single_set(device, init, fname, init_op, op, end_op, 1)
+    _drned_single_set(device, init, fname, init_op, op, end_op, 1, not unsorted)
 
-def test_template_union(device, init, fname, init_op, iteration):
+def test_template_union(device, init, fname, init_op, iteration, unsorted):
     """Test of all combinations of file sets.
 
     This test is using the device fixture, which means that the device
@@ -188,7 +188,7 @@ def test_template_union(device, init, fname, init_op, iteration):
                 end_op = []
             # Load the entire collection of sets
             commit_id_base = len(device.commit_id)
-            _drned_single_set(device, init, fname, init_op, op, end_op, it)
+            _drned_single_set(device, init, fname, init_op, op, end_op, it, not unsorted)
             # Final commit
             if it in [5, 6]:
                 device.commit_compare(dry_run=False)
@@ -200,7 +200,7 @@ def test_template_union(device, init, fname, init_op, iteration):
                 device.rollback_compare(id=device.commit_id[i], dry_run=False)
 
 # Test single set
-def _drned_single_set(device, init, fname, init_op, op, end_op, it):
+def _drned_single_set(device, init, fname, init_op, op, end_op, it, sort):
     src_in_set = False
     device.save("drned-work/before-test.cfg")
     # Load init files
@@ -216,9 +216,11 @@ def _drned_single_set(device, init, fname, init_op, op, end_op, it):
     if not fname:
         pytest.fail("Please specify a file with the --fname option")
     # Divide in sets
-    tsets = sorted(list(set([re.sub(":[^\.]*", ":*", f) for f in fname])))
-    if not it % 2:
-        tsets = reversed(tsets)
+    tsets = [re.sub(":[^\.]*", ":*", f) for f in fname]
+    if sort:
+        tsets = sorted(list(set(tsets)))
+        if not it % 2:
+            tsets = reversed(tsets)
     if op == None:
         op = ["load", "commit", "compare-config"]
     pinit = " --init=" + " --init=".join(init) if init else ""

--- a/drned/drned/fixtures.py
+++ b/drned/drned/fixtures.py
@@ -37,6 +37,8 @@ def pytest_addoption(parser):
                      help="operations to perform")
     parser.addoption("--root", action="store", dest="root",
                      help="select traversal root")
+    parser.addoption("--unsorted", action="store_true", dest="unsorted",
+                     help="do not reorder config files (fnames)"),
     parser.addoption("--use", action="append", dest="use",
                      help="add drned use_xxx parameter")
     parser.addoption("--yangpath", action="append", dest="yangpath",
@@ -151,6 +153,16 @@ def device_raw(request):
 @pytest.yield_fixture(scope=SCOPE)
 def yangpath(request):
     yield request.config.getoption("--yangpath")
+
+
+@pytest.yield_fixture(scope=SCOPE)
+def unsorted(request):
+    option = request.config.getoption("--unsorted")
+    if option is None:
+        yield False
+    else:
+        yield option
+
 
 @pytest.yield_fixture(scope=SCOPE)
 def schema(request):


### PR DESCRIPTION
The fixture is necessary for "walk-states" test; the original DrNED contains it only in my branch (and pull request).