### PR TITLE
fix for saving empty configs in XML format

### DIFF
--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -136,13 +136,13 @@ class RecordStateOp(ConfigOp):
            <xsl:strip-space elements="*"/>
            <xsl:template xmlns:config="http://tail-f.com/ns/config/1.0" xmlns:ncs="http://tail-f.com/ns/ncs"
                          match="/config:config/ncs:devices/ncs:device">
-              <xsl:apply-templates select="ncs:config"/>
+              <config xmlns="http://tail-f.com/ns/config/1.0">
+                <xsl:apply-templates select="ncs:config"/>
+              </config>
            </xsl:template>
 
            <xsl:template xmlns:ncs="http://tail-f.com/ns/ncs" match="ncs:config">
-              <config xmlns="http://tail-f.com/ns/config/1.0">
-                <xsl:copy-of select="*"/>
-              </config>
+              <xsl:copy-of select="*"/>
            </xsl:template>
         </xsl:stylesheet>''')
                     tree = etree.fromstringlist(save_data)


### PR DESCRIPTION
Recording empty configuration in XML format would fail since no element would match `ncs:config` and the result would be an empty document - `lxml` returns `None` in such case. This is fixed by generating the element `config:config` already in the outer template.