### PR TITLE
deprecation warnings fixes (escape sequences in regexes, PEP 479)

### DIFF
--- a/python/drned_xmnr/op/filtering.py
+++ b/python/drned_xmnr/op/filtering.py
@@ -259,7 +259,12 @@ class EventGenerator(Closeable):
         super(EventGenerator, self).__init__(cort, consumer)
 
     def close(self):
-        self.consumer.send(TerminateEvent())
+        try:
+            # we need to let the consumer know; but it can raise
+            # StopIteration
+            self.consumer.send(TerminateEvent())
+        except StopIteration:
+            pass
         self.coroutine.close()
 
 
@@ -272,13 +277,13 @@ line_regexp = re.compile('''\
 (?P<transition>Transition [0-9]*/[0-9]*: .* ==> .*)|\
 (?P<init_failed>Failed to initialize state .*)|\
 (?P<trans_failed>Transition failed)|\
-(?P<drned>={30} (?P<drned_op>rload|commit|compare_config|rollback)\(.*\))|\
-(?P<no_modifs>% No modifications to commit\.)|\
-(?P<commit_queue>commit-queue \{)|\
+(?P<drned>={30} (?P<drned_op>rload|commit|compare_config|rollback)\\(.*\\))|\
+(?P<no_modifs>% No modifications to commit\\.)|\
+(?P<commit_queue>commit-queue \\{)|\
 (?P<commit_result> *status (?P<result>completed|failed))|\
 (?P<failure_reason> *reason (?P<reason>RPC error .*))|\
 (?P<teardown>### TEARDOWN, RESTORE DEVICE ###)|\
-(?P<restore>={30} load\(drned-work/before-session.xml\))|\
+(?P<restore>={30} load\\(drned-work/before-session.xml\\))|\
 (?P<diff>diff *)\
 )$''')
 

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -928,7 +928,7 @@ class TestTransitionsLogFiltersRedirect(TransitionsLogFiltersTestBase):
         with open(os.path.join(xmnr_dir, 'redirect.output')) as r_out:
             assert r_out.readline() == '\n'
             assert re.match('-+$', r_out.readline()) is not None
-            assert re.match('[0-9]{4}(-[0-9]{2}){2} [0-9]{2}(:[0-9]{2}){2}\.[0-9]* - walk states$',
+            assert re.match(r'[0-9]{4}(-[0-9]{2}){2} [0-9]{2}(:[0-9]{2}){2}\.[0-9]* - walk states$',
                             r_out.readline()) is not None
             assert re.match('-+$', r_out.readline()) is not None
             assert ''.join(drned_output.expected_output()) == r_out.read()


### PR DESCRIPTION
Recent versions of Python3 issue deprecation warnings for incorrect escape sequences and for the use (or unhandled occurrence) of StopIteration in a generator. The change is fixing them.