### PR TITLE
Remove the --unsorted flag which needed/supported anymore. The use of…

### DIFF
--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -207,7 +207,7 @@ class WalkTransitionsOp(ExploringOp):
         # if rollback is not desired, we need to set it to an empty list
         fname_args = ["--fname=" + filename for filename in self.state_filenames]
         end_op = [] if self.rollback else ["--end-op", ""]
-        result, _ = self.drned_run(fname_args + end_op + ["--unsorted", "-k", "test_template_set"])
+        result, _ = self.drned_run(fname_args + end_op + ["--ordered=false", "-k", "test_template_set"])
         self.log.debug("DrNED completed: {0}".format(result))
         if result != 0:
             raise ActionError("drned failed")

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -538,7 +538,7 @@ class TestTransitions(TransitionsTestBase):
                          for state in self.states]
             if not rollback:
                 test_args += ['--end-op', '']
-            test_args += ['--unsorted', '-k', 'test_template_set']
+            test_args += ['--ordered=false', '-k', 'test_template_set']
         args = ['py.test', '-s', '--tb=short', '--device=' + mocklib.DEVICE_NAME]
         if not builtin_drned:
             args.append('--unreserved')


### PR DESCRIPTION
… this flag prevented the walk-states command from working.