### PR TITLE
separate drned logs and redirect logs for devices

### DIFF
--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -74,7 +74,7 @@ class ActionBase(XmnrBase):
 
     @contextmanager
     def open_log_file(self, path):
-        with open(os.path.join(self.xmnr_directory, path), 'a') as lf:
+        with open(os.path.join(self.dev_test_dir, path), 'a') as lf:
             msg = '{} - {}'.format(dt.now(), self.action_name)
             lf.write('\n{}\n{}\n{}\n'.format('-'*len(msg), msg, '-'*len(msg)))
             yield lf

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -922,10 +922,9 @@ class TestTransitionsLogFiltersRedirect(TransitionsLogFiltersTestBase):
     def test_filter_redirect(self, xpatch):
         self.setup_filter(xpatch, 'drned-overview', 'redirect.output')
         self.setup_states_data(xpatch.system)
-        xmnr_dir = mocklib.XMNR_DIRECTORY
         drned_output = DrnedWalkOutput(self.states, 'drned-overview', xpatch.system)
         self.invoke_action('walk-states', states=self.states, rollback=False)
-        with open(os.path.join(xmnr_dir, 'redirect.output')) as r_out:
+        with open(os.path.join(self.test_run_dir, 'redirect.output')) as r_out:
             assert r_out.readline() == '\n'
             assert re.match('-+$', r_out.readline()) is not None
             assert re.match('[0-9]{4}(-[0-9]{2}){2} [0-9]{2}(:[0-9]{2}){2}\.[0-9]* - walk states$',


### PR DESCRIPTION
Log files storing DrNED and filtered DrNED output were global; this is causing issues when multiple tests are run in parallel towards multiple devices. This change makes the two files local per device. Related to #5.