### PR TITLE
Update section header [pytest] -> [tool:pytest].

### DIFF
--- a/drned/adm/setup.cfg
+++ b/drned/adm/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = drned-* lux


### PR DESCRIPTION
The new format has been understood by pytest for three years and is
required by ptest 4.2.0 and later versions.

Signed-off-by: Jonas Johansson <jojohans@cisco.com>