### PR TITLE
EXIT_INTERRUPTED not used, does not exist in new pytest

### DIFF
--- a/drned/drned/fixtures.py
+++ b/drned/drned/fixtures.py
@@ -6,7 +6,6 @@ import pwd
 import subprocess
 import sys
 import common.test_common as common
-from _pytest.main import EXIT_INTERRUPTED
 
 SCOPE = "session"
 


### PR DESCRIPTION
Recent pytest version renamed a constant which is imported (but not used) in the drned stub code.