### PR TITLE
requirements stated more explicitly

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pexpect = "*"
+pytest = ">=3.0"
+lxml = "*"
+
+[requires]
+python_version = "2.7"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,59 @@ package. Using the tool's actions you can:
 
 ## Prerequisites
 
-The only prerequisite is the DrNED dependencies, in particular `pytest`,
-`pexpect`, and `lxml`.
+The prerequisites are given by what DrNED needs to run, the first and foremost
+requirement is Python 2.7.  Apart form that, several Python packages are
+needed: `pytest`, `pexpect`, and `lxml`, and `pytest` version needs to be at
+least 3.0.  There are several options how to install these packages:
+
+1. Quite likely, they are available in your system distribution repositories;
+   for example in Ubuntu they can be installed like
+
+        $ sudo apt install python-pytest python-lxml python-pexpect
+       
+   Care must be taken though if the `pytest` version meets requirements,
+   namely on Ubuntu 16.04 it does not:
+
+        $ apt show python-pytest
+        ...
+        Version: 2.8.7-4
+
+2. All three packages are published through the Python Package Inventory and
+   can be installed from there; it requires that `pip` is installed (on Ubuntu
+   as `python-pip`).  The requirements are enumerated in `requirements.txt`
+   file that can be provided to pip:
+
+        $ pip install --user -r requirements.txt
+
+   or for a system-wide installation
+
+        $ sudo pip install -r requirements.txt
+       
+ 3. If it is required that the packages are not only user-specific but also a
+    project-specific, it is possible to use so called python virtual
+    environments.  Using them can be greatly simplified by the tool `pipenv`
+    which needs to be installed first (globally or per user):
+    
+        $ pip install --user pipenv
+       
+    or
+
+        $ sudo pip install pipenv
+       
+    Have a look at the file `Pipfile` - it tells `pipenv` what packages and in
+    what versions need to be installed for the project environment.  The
+    environment can be created with required packages using
+    
+        $ pipenv install
+       
+    Now, so as to enter the environment, run
+    
+        $ pipenv shell
+
+    This starts a new OS shell with paths pointing to the installed packages.
+    NSO or at least its Python VM should be started from this shell (see also
+    the command `pipenv run` for an alternative method).
+
 
 ## What it can do
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pexpect
+pytest>=3.0
+lxml


### PR DESCRIPTION
Added `requirements.txt` (to be used by `pip`) and `Pipfile` (to be used by `pipenv`). Expanded README to describe in more detail what is required by the tool and how to install it.