### PR TITLE
incorporating changes in the device fixture in the original DrNED

### DIFF
--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -10,21 +10,11 @@
     !make -C ned/src all
     [invoke shell-check]
     [timeout]
-    [progress create and start the netsim]
     !cd ..
-    !ncs-netsim delete-network
-    !ncs-netsim create-network packages/ned 1 ned
-    [invoke shell-check]
-    !ncs-netsim start
-    [invoke shell-check]
-    [progress start ncs]
-    [timeout 10]
-    !ncs --stop; ncs
-    [invoke shell-check]
-    [timeout]
+    [invoke start-ncs-netsim ned]
 
 [shell ncs-cli]
-    [invoke prepare-test dhcp netconf 12022]
+    [invoke prepare-test ned0]
     !config dhcp defaultLeaseTime 200s
     !commit
     ???Commit complete.
@@ -37,37 +27,7 @@
     ???success
     !drned-xmnr state check-states validate true
     ???success all states are consistent
-    [progress walk states]
-    [timeout 15]
-    !drned-xmnr transitions walk-states states [ empty subnet time ]
-    """???
-    Prepare the device
-    Test transition to empty
-       load empty
-       commit
-           succeeded
-       compare config
-           succeeded
-    Test transition to subnet
-       load subnet
-       commit
-           succeeded
-       compare config
-           succeeded
-    Test transition to time
-       load time
-       commit
-           succeeded
-       compare config
-           succeeded
-    Device cleanup
-       load before-session
-       commit
-           succeeded
-       compare config
-           succeeded
-    success Completed successfully
-    """
+    [invoke test-walk-states "empty subnet time"]
 
 [cleanup]
     [invoke cleanup]

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -1,0 +1,34 @@
+[doc Testing DrNED-XMNR integration with NCS and DrNED; CLI device interaction]
+
+[include common.luxinc]
+
+[shell os]
+    [invoke ned-test-setup]
+    !ls -d $NCS_DIR/packages/neds/*-ios-cli* | tail -1
+    ?(cisco-ios.*)
+    !cp -r $NCS_DIR/packages/neds/$1 cisco-ios
+    [invoke shell-check]
+    [timeout 30]
+    !make -C cisco-ios/src all
+    [invoke shell-check]
+    [timeout]
+    !cd ..
+    [invoke start-ncs-netsim cisco-ios]
+
+[shell ncs-cli]
+    [invoke prepare-test cisco-ios0]
+    !top show full devices device cisco-ios0 config ios:ip
+    !config ios:interface GigabitEthernet 2 ip address 10.10.10.10 255.255.255.0
+    !commit
+    ???Commit complete.
+    # watch for autoconfigs
+    !sync-from
+    ?result true
+    !drned-xmnr state record-state state-name if
+    ???success
+    [progress walk states]
+    [timeout 20]
+    [invoke test-walk-states "empty if"]
+
+[cleanup]
+    [invoke cleanup]

--- a/test/lux/common.luxinc
+++ b/test/lux/common.luxinc
@@ -21,45 +21,59 @@
     [invoke shell-check]
 [endmacro]
 
-[macro prepare-test device type port]
-    # capture the ncs version; for 5.1+ we need to configure ned-id
-    !ncs --version | (echo -n ned-id ' '; sed -e 's/^5\.[1-9].*\|^[6-9].*/ ned-id ned-nc-1.0/' -e 's/^[45].*//')
-    ?^ned-id (.*)[\r\n]
-    [local nedid=$1]
-    -[Ee][Rr][Rr][Oo][Rr]
+[macro start-ncs-netsim device]
+    [progress create and start the netsim]
+    !ncs-netsim delete-network
+    !ncs-netsim create-network packages/$device 1 $device
+    [invoke shell-check]
+    !ncs-netsim start
+    [invoke shell-check]
+    [progress start ncs]
+    [timeout 10]
+    !ncs --stop; ncs
+    [invoke shell-check]
+    [timeout]
+[endmacro]
+
+[macro test-walk-states states]
+    [progress walk states]
+    [timeout 15]
+    !drned-xmnr transitions walk-states states [ $states ]
+    ?Prepare the device
+    [loop state $states]
+        """?
+        Test transition to $state
+           load $state
+           commit
+               succeeded
+           compare config
+               succeeded
+        """
+    [endloop]
+    """?
+    Device cleanup
+       load before-session
+       commit
+           succeeded
+       compare config
+           succeeded
+    success Completed successfully
+    """
+[endmacro]
+
+[macro prepare-test device]
+    !ncs_cmd -u admin -c 'mdel /devices/device{$device}'
+    !ncs-netsim --dir ncs-run/netsim ncs-xml-init $device | sed -e 's/10022/12022/' -e 's/cli>/netconf>/' | ncs_load -F p -l -m
+    [invoke shell-check]
     !ncs_cli -u admin -C
     ???admin@ncs#
     !complete-on-space false
     !config
-    [progress set up the NCS device]
-    # clean up, if there is anything left from previous runs
-    !no devices device $device
-    # set up python-vm logging to see any problems
     !python-vm logging level level-debug
     !commit
     ?Commit complete|No modifications.
     !devices device $device
-    ??admin@ncs(config-device-$device)#
-    """!
-    address 127.0.0.1
-    port $port
-    device-type $type$nedid
-    authgroup default
-    state admin-state unlocked
-    """
-    !commit
-    ???Commit complete.
-    !ssh fetch-host-keys
-    ???result updated
     !sync-from
-    !no config
-    !commit
-    [timeout 10]
-    ?Commit complete|No modifications to commit
-    # watch for autoconfigs
-    !sync-from
-    ?result true
-    [timeout]
     [progress setup xmnr]
     !drned-xmnr setup setup-xmnr overwrite true
     ???success
@@ -76,5 +90,7 @@
     !ncs-netsim stop
     ?SH-PROMPT:
     !make clean
+    ?SH-PROMPT:
+    !rm -rf packages/*
     ?SH-PROMPT:
 [endmacro]

--- a/test/unit/tox.ini
+++ b/test/unit/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36
+envlist = py27, py37
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
The problem is in that DrNED used "load replace" to restore the original device configuration and this usually fails; its current code works around the problem by simply erasing the device config and "load merge" the saved configuration. This commit uses the new device fixture code.