### PR TITLE
Mvolf/state names

### DIFF
--- a/drned/common/test_template.py
+++ b/drned/common/test_template.py
@@ -378,7 +378,8 @@ def _drned_single_file(device, name, op, commit_id_base=None):
 def _drned_template_load(device, template, fail_on_errors=True):
     fname = template.replace("~", "-")
     if fname.endswith(".xml"):
-        device.load(fname, rename_device=True, fail_on_errors=fail_on_errors)
+        device.load(fname, rename_device=True, fail_on_errors=fail_on_errors,
+                    xload=True)
     else:
-        device.rload(fname, remove_device=True, fail_on_errors=fail_on_errors)
-
+        device.rload(fname, remove_device=True, fail_on_errors=fail_on_errors,
+                     xload=True)

--- a/drned/drned/device.py
+++ b/drned/drned/device.py
@@ -282,7 +282,7 @@ class Device(object):
         return self
 
     def load(self, name, mode="merge", fail_on_errors=True, rename_device=False,
-             ancient=False):
+             ancient=False, xload=False):
         """Load device configuration from file.
 
         The load operation can read additional load information from a
@@ -328,6 +328,9 @@ class Device(object):
             if lmode:
                 mode = lmode.group(1)
 
+        if xload and mode == 'override':  # broken in 5.3.2 and later - ENG-24198
+            self.cmd('no devices device {} config'.format(self.name))
+            mode = 'merge'
         expect_not = None
         if not fail_on_errors:
             expect_not = "(ERROR|[Ee]rror|Failed|Aborted):(?! incomplete| on line| bad value)"
@@ -339,7 +342,7 @@ class Device(object):
         return self
 
     def rload(self, name, mode="merge", fail_on_errors=True, remove_device=False,
-              set_path=True, banner=True):
+              set_path=True, banner=True, xload=False):
         """Load device configuration from file at current position.
 
         The rload operation can read additional load information from
@@ -398,6 +401,9 @@ class Device(object):
                                              delete=False) as temp:
                 name = self._new_device_name(name, temp, remove=True)
                 rm = None if name == temp.name else temp.name
+        if xload and mode == 'override':  # broken in 5.3.2 and later - ENG-24198
+            self.cmd('no devices device {} config'.format(self.name))
+            mode = 'merge'
         if set_path and path:
             self.cmd(path)
         expect_not = None

--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -56,9 +56,8 @@ class SetupOp(base_op.ActionBase):
         if self.overwrite and os.path.exists(target):
             try:
                 shutil.rmtree(target, ignore_errors=True)
-                os.remove(target)
             except OSError as ose:
-                if ose.errno != errno.ENOENT:		
+                if ose.errno != errno.ENOENT:
                     msg = "Failed to remove the old drned directory {0}" \
                           .format(os.strerror(ose.errno))
                     raise ActionError(msg)

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -29,6 +29,13 @@ module drned-xmnr {
   typedef dirpath-type {
     type string;
   }
+  typedef state-file-format {
+    type enumeration {
+      enum xml;
+      enum c-style;
+    }
+    default xml;
+  }
 
   container drned-xmnr {
     leaf drned-directory {
@@ -128,6 +135,10 @@ module drned-xmnr {
               mandatory true;
               type string;
             }
+            leaf overwrite {
+              type boolean;
+              default false;
+            }
             leaf including-rollbacks {
               type uint32 {
                 range 0..25;
@@ -135,11 +146,7 @@ module drned-xmnr {
               default 0;
             }
             leaf format {
-              type enumeration {
-                enum xml;
-                enum c-style;
-              }
-              default c-style;
+              type state-file-format;
             }
           }
           output {
@@ -210,6 +217,9 @@ module drned-xmnr {
                 enum nso-c-style;
               }
               default xml;
+            }
+            leaf target-format {
+              type state-file-format;
             }
             leaf overwrite {
               type boolean;

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -18,8 +18,10 @@
     !config dhcp defaultLeaseTime 200s
     !commit
     ???Commit complete.
-    !drned-xmnr state record-state state-name time
+    !drned-xmnr state record-state state-name time format c-style overwrite true
     ???success
+    !drned-xmnr state record-state state-name time
+    ???failure state time already exists
     ~drned-xmnr state import-state-files
     ! file-path-pattern ../subnet.xml merge false overwrite true
     ???success

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -24,7 +24,7 @@
     # watch for autoconfigs
     !sync-from
     ?result true
-    !drned-xmnr state record-state state-name if
+    !drned-xmnr state record-state state-name if overwrite true
     ???success
     [progress walk states]
     [timeout 20]

--- a/test/lux/common.luxinc
+++ b/test/lux/common.luxinc
@@ -76,10 +76,10 @@
     !sync-from
     [progress setup xmnr]
     !drned-xmnr setup setup-xmnr overwrite true
-    ???success
+    ???success XMNR set up
     [progress record states]
-    !drned-xmnr state record-state state-name empty
-    ???success
+    !drned-xmnr state record-state state-name empty overwrite true
+    ???success Recorded state
 [endmacro]
 
 [macro cleanup]


### PR DESCRIPTION
The first commit implements simple work around the bug ENG-24198; the second one forces usage of XML format for state files and fixes several format-related bugs. The second makes it is necessary that XML and C-style state files have different extension, which forces many changes in how state files are recorded/imported, and to some extent how are processed elsewhere.