### PR TITLE
working with pytest>=6.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,5 @@ verify_ssl = true
 
 [packages]
 pexpect = "*"
-pytest = ">=3.0,<6.0.0"
+pytest = ">=3.0"
 lxml = "*"

--- a/drned/drned/fixtures.py
+++ b/drned/drned/fixtures.py
@@ -54,8 +54,7 @@ def pytest_generate_tests(metafunc):
                 for f in files:
                     if os.path.splitext(f)[1] in [".cfg", ".txt", ".xml", ".init"]:
                         fn = (os.path.join(root, f)
-                              .replace("../%s/" % os.path.basename(os.getcwd()), "")
-                              .replace("-", "~"))
+                              .replace("../%s/" % os.path.basename(os.getcwd()), ""))
                         filenames.append(fn)
         return filenames
 
@@ -63,7 +62,8 @@ def pytest_generate_tests(metafunc):
     if "template" in metafunc.fixturenames:
         filenames = get_filenames()
         if filenames:
-            metafunc.parametrize("template", filenames, scope=SCOPE)
+            metafunc.parametrize("template", filenames, ids=os.path.basename,
+                                 scope=SCOPE)
 
     # Look for fname files
     if "fname" in metafunc.fixturenames:

--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -57,15 +57,12 @@ class TransitionsOp(base_op.ActionBase):
     def transition_to_state(self, state_name, rollback=False):
         filename = self.state_name_to_filename(state_name)
         self.log.debug("Transition_to_state: {0}\n".format(state_name))
-        # filename needs to use '~' instead of '-'
-        # need to use relative path for DrNED to accept that
-        filepath = os.path.relpath(filename, self.drned_run_directory).replace("-", "~")
-
+        filepath = os.path.relpath(filename, self.drned_run_directory)
         self.log.debug("Using file {0}\n".format(filepath))
         # Max 120 seconds for executing DrNED
         self.extend_timeout(120)
         test = "test_template_single" if rollback else "test_template_raw"
-        args = ["-k {0}[{1}]".format(test, filepath)]
+        args = ["-k {0}[{1}]".format(test, os.path.basename(filepath))]
         result, _ = self.drned_run(args)
         self.log.debug("Test case completed\n")
         if result != 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pexpect
-pytest>=3.0,<6.0.0
+pytest>=3.0
 lxml

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -542,7 +542,7 @@ class TestTransitions(TransitionsTestBase):
     def check_drned_call(self, call, state=None, rollback=False, fnames=None, builtin_drned=False):
         if fnames is None:
             test = 'test_template_single' if rollback else 'test_template_raw'
-            test_args = ['-k {}[../states/{}.state.cfg]'.format(test, state)]
+            test_args = ['-k {}[{}.state.cfg]'.format(test, state)]
         else:
             test_args = ['--fname={}'.format(os.path.join(self.test_run_dir,
                                                           'states',


### PR DESCRIPTION
In pytest>=6.0 some characters are no longer allowed in test parameters. For some DrNED tests we were using file paths as test parameters, moreover conversion `'-' -> '~'` was done (perhaps for some legacy reasons); neither `'/'` or `'~'` are allowed. Change consists of two small parts:
- In DrNED, assign IDs to file parameters; the ID is created as the base name of the file. The conversion `'-' -> '~'` is not necessary, so it was removed.
- In XMNR, use just IDs, i.e. the file name without the path part.

It is yet another step away from the original DrNED, albeit small.

The change seems to be backward compatible (at least seems to work with pytest-5.4.3).