### PR TITLE
No commit queues

### DIFF
--- a/python/drned_xmnr/op/filtering.py
+++ b/python/drned_xmnr/op/filtering.py
@@ -310,6 +310,7 @@ line_regexp = re.compile('''\
 (?P<drned>={30} (?P<drned_op>commit|compare_config|rollback)\\(.*\\))|\
 (?P<no_modifs>% No modifications to commit\\.)|\
 (?P<commit_queue>commit-queue \\{)|\
+(?P<commit_noqueue>commit)|\
 (?P<commit_nn>commit no-networking)|\
 (?P<commit_complete>Commit complete\\.)|\
 (?P<commit_result> *status (?P<result>completed|failed))|\
@@ -352,6 +353,9 @@ def event_generator(consumer):
                 consumer.send(DrnedEmptyCommit())
             elif match.lastgroup == 'commit_queue':
                 consumer.send(DrnedCommitLogEvent())
+            elif match.lastgroup == 'commit_noqueue':
+                consumer.send(DrnedCommitLogEvent())
+                consumer.send(DrnedCommitResult('commit', True))
             elif match.lastgroup == 'commit_nn':
                 consumer.send(DrnedCommitNNEvent())
             elif match.lastgroup == 'commit_result':

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -110,6 +110,12 @@ module drned-xmnr {
               type boolean;
               default false;
             }
+            leaf use-commit-queue {
+              tailf:info "Commit queue should be used for testing this
+                          device.";
+              type boolean;
+              default true;
+            }
           }
           output {
             uses action-output-common;

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -1,6 +1,7 @@
 [doc Testing DrNED-XMNR integration with NCS and DrNED]
 
 [include common.luxinc]
+[global ned0_log=/tmp/xmnr/ned0/test/output.log]
 
 [shell os]
     [invoke ned-test-setup]
@@ -12,9 +13,22 @@
     [timeout]
     !cd ..
     [invoke start-ncs-netsim ned]
-
 [shell ncs-cli]
-    [invoke prepare-test ned0]
+    [invoke prepare-ncs ned0]
+
+    [loop queues true false]
+[shell os]
+    !rm -f $ned0_log
+    !$queues && echo -n en || echo -n dis; echo abled
+    ?(disabled|enabled)
+    [my qtest=$1]
+    !$queues && echo -n dis || echo -n en; echo abled
+    ?(disabled|enabled)
+    [my neg_qtest=$1]
+    !tail -F $ned0_log
+    -Commit queues are $neg_qtest
+[shell ncs-cli]
+    [invoke prepare-xmnr $queues]
     !config dhcp defaultLeaseTime 200s
     !commit
     ???Commit complete.
@@ -28,6 +42,17 @@
     !drned-xmnr state check-states validate true
     ???success all states are consistent
     [invoke test-walk-states "empty subnet time"]
+[shell os]
+    """?
+    -----*
+    .* - walk states
+    -----*
+    """
+    ?Commit queues are $qtest
+    ?====* 1 passed, .* ====*
+    ~$_CTRL_C_
+    ?SH-PROMPT:
+    [endloop]
 
 [cleanup]
     [invoke cleanup]

--- a/test/lux/common.luxinc
+++ b/test/lux/common.luxinc
@@ -62,6 +62,11 @@
 [endmacro]
 
 [macro prepare-test device]
+    [invoke prepare-ncs $device]
+    [invoke prepare-xmnr true]
+[endmacro]
+
+[macro prepare-ncs device]
     !ncs_cmd -u admin -c 'mdel /devices/device{$device}'
     !ncs-netsim --dir ncs-run/netsim ncs-xml-init $device | sed -e 's/10022/12022/' -e 's/cli>/netconf>/' | ncs_load -F p -l -m
     [invoke shell-check]
@@ -70,12 +75,18 @@
     !complete-on-space false
     !config
     !python-vm logging level level-debug
+    !drned-xmnr xmnr-log-file output.log
     !commit
     ?Commit complete|No modifications.
     !devices device $device
     !sync-from
+[endmacro]
+
+[macro prepare-xmnr queues]
+    !no config
+    !commit
     [progress setup xmnr]
-    !drned-xmnr setup setup-xmnr overwrite true
+    !drned-xmnr setup setup-xmnr overwrite true use-commit-queue $queues
     ???success XMNR set up
     [progress record states]
     !drned-xmnr state record-state state-name empty overwrite true

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -149,16 +149,13 @@ drned_transition_output_filtered = '''\
 '''
 
 
-drned_walk_output = '''\
+drned_walk_output_base = '''\
 --generic drned data--
-============================== rload(../states/{state_to}.state.cfg)
+============================== rload(../states/{{state_to}}.state.cfg)
 --generic drned data--
 ============================== commit()
 --generic drned data--
-commit-queue {{
-    id 1529566672491
-    status completed
-}}
+{commit_message}
 Commit complete.
 --generic drned data--
 ============================== compare_config()
@@ -167,14 +164,20 @@ Commit complete.
 --generic drned data--
 ============================== commit()
 --generic drned data--
-commit-queue {{
-    id 1529566674280
-    status completed
-}}
+{commit_message}
 --generic drned data--
 ============================== compare_config()
 --generic drned data--
 '''
+
+commit_queue_message = '''\
+commit-queue {{
+    id 1529566674280
+    status completed
+}}
+'''
+drned_walk_output = drned_walk_output_base.format(commit_message=commit_queue_message)
+drned_walk_output_noqueues = drned_walk_output_base.format(commit_message='commit')
 
 drned_walk_output_outro = '''\
 ### TEARDOWN, RESTORE DEVICE ###
@@ -324,7 +327,7 @@ class TestSetup(TestBase):
         self.setup_fs_data(xpatch.system)
         self.setup_ncs_data(xpatch.ncs)
         xpatch.system.socket_data(device_data.encode())
-        output = self.invoke_action('setup-xmnr', overwrite=True)
+        output = self.invoke_action('setup-xmnr', overwrite=True, use_commit_queue=True)
         self.check_output(output)
         with open(os.path.join(self.test_run_dir, 'drned-skeleton', 'skeleton')) as skel_test:
             assert skel_test.read() == 'drned skeleton'


### PR DESCRIPTION
The first commit adds a switch to disable commit queues for a device during xmnr-setup; the second fixes walk-transitions and explore-transitions output and adds a test to verify the switch behavior.