### PR TITLE
".state." part of the state file is now optional

### DIFF
--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -30,6 +30,8 @@ else:
 class XmnrBase(object):
     xml_statefile_extension = '.state.xml'
     cfg_statefile_extension = '.state.cfg'
+    xml_extensions = [xml_statefile_extension, '.xml']
+    cfg_extensions = [cfg_statefile_extension, '.cfg']
 
     def __init__(self, dev_name, log_obj):
         self.dev_name = dev_name
@@ -48,19 +50,21 @@ class XmnrBase(object):
         except OSError:
             pass
 
-    def format_state_filename(self, statename, format='xml'):
+    def format_state_filename(self, statename, format='xml', suffix=None):
         """Just convert the state name to the right filename."""
-        suffix = (self.cfg_statefile_extension if format == 'cfg'
-                  else self.xml_statefile_extension)
+        if suffix is None:
+            suffix = (self.cfg_statefile_extension if format == 'cfg'
+                      else self.xml_statefile_extension)
         return os.path.join(self.states_dir, statename + suffix)
 
     def state_name_to_existing_filename(self, statename, format='any'):
+        suffixes = []
         if format != 'cfg':
-            path = self.format_state_filename(statename, format='xml')
-            if os.path.exists(path):
-                return path
+            suffixes += self.xml_extensions
         if format != 'xml':
-            path = self.format_state_filename(statename, format='cfg')
+            suffixes += self.cfg_extensions
+        for suffix in suffixes:
+            path = self.format_state_filename(statename, suffix=suffix)
             if os.path.exists(path):
                 return path
         return None
@@ -82,7 +86,9 @@ class XmnrBase(object):
                                           format=('xml' if format != 'cfg' else 'cfg'))
 
     def state_filename_to_name(self, filename):
-        return os.path.basename(filename)[:-len(self.xml_statefile_extension)]
+        for extension in self.xml_extensions + self.cfg_extensions:
+            if filename.endswith(extension):
+                return os.path.basename(filename)[:-len(extension)]
 
     def get_states(self):
         return [self.state_filename_to_name(f) for f in self.get_state_files()]

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -171,7 +171,6 @@ class ImportStateFiles(ConfigOp):
         checks = [self.state_name_to_existing_filename(state) for state in states]
         conflicts = {self.state_filename_to_name(filename) for filename in checks
                      if filename is not None}
-        self.log.info(f'import {self.pattern}, {states}, {checks}, {conflicts}')
         if not self.overwrite:
             if conflicts:
                 raise ActionError("States already exists: " + ", ".join(conflicts))

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -171,6 +171,7 @@ class ImportStateFiles(ConfigOp):
         checks = [self.state_name_to_existing_filename(state) for state in states]
         conflicts = {self.state_filename_to_name(filename) for filename in checks
                      if filename is not None}
+        self.log.info(f'import {self.pattern}, {states}, {checks}, {conflicts}')
         if not self.overwrite:
             if conflicts:
                 raise ActionError("States already exists: " + ", ".join(conflicts))

--- a/python/drned_xmnr/op/filtering.py
+++ b/python/drned_xmnr/op/filtering.py
@@ -443,6 +443,9 @@ class ExploreLogState(LogState):
 
 
 class WalkLogState(LogState):
+    ignored_events = [DrnedEmptyCommit, DrnedCommitComplete, DrnedCommitLogEvent,
+                      DrnedCommitResult]
+
     def __init__(self, level):
         self.level = level
 
@@ -454,16 +457,16 @@ class WalkLogState(LogState):
             if self.level == 'overview':
                 return event.produce_line()
             return (event.produce_line(), DrnedLogState())
-        if not isinstance(event, DrnedEmptyCommit) and \
-           not isinstance(event, DrnedCommitComplete):
-            # commits can occur on this level
-            return event.produce_line()
-        return None
+        for clz in self.ignored_events:
+            if isinstance(event, clz):
+                # commits can occur on this level
+                return None
+        return event.produce_line()
 
 
 class DrnedLogState(LogState):
     def handle(self, event):
-        if isinstance(event, DrnedEmptyCommit):
+        if isinstance(event, DrnedCommitEvent):
             event.mark_complete()
             return None
         if not isinstance(event, DrnedActionEvent):

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -1,7 +1,8 @@
 [doc Testing DrNED-XMNR integration with NCS and DrNED]
 
 [include common.luxinc]
-[global ned0_log=/tmp/xmnr/ned0/test/output.log]
+[global ned0_dir=/tmp/xmnr/ned0]
+[global ned0_log=$ned0_dir/test/output.log]
 
 [shell os]
     [invoke ned-test-setup]
@@ -16,7 +17,42 @@
 [shell ncs-cli]
     [invoke prepare-ncs ned0]
 
+    [invoke prepare-xmnr true]
+    !config dhcp defaultLeaseTime 200s
+    !commit
+    ???Commit complete.
+    !drned-xmnr state record-state state-name time format c-style overwrite true
+    ???success
+    !drned-xmnr state record-state state-name time
+    ???failure state time already exists
+    ~drned-xmnr state import-state-files
+    ! file-path-pattern ../subnet.xml merge false overwrite true
+    ???success
+[shell os]
+    !cp -v ../subnet2.xml $ned0_dir/test/states/
+    ??'../subnet2.xml' -> '$ned0_dir/test/states/subnet2.xml'
+    ?SH-PROMPT
+[shell ncs-cli]
+    !drned-xmnr state record-state state-name subnet2
+    ???failure state subnet2 already exists
+[shell os]
+    ~netconf-console --get -x /devices/device/drned-xmnr/state/states |
+    ~sed -n 's%.*<state>\(.*\)</state>.*%\1%p' |
+    !sort
+    """?
+    netconf-console --get .*
+    empty
+    subnet
+    subnet2
+    time
+    SH-PROMPT
+    """
+[shell ncs-cli]
+    !drned-xmnr state check-states validate true
+    ???success all states are consistent
+
     [loop queues true false]
+        [invoke prepare-xmnr $queues]
 [shell os]
     !rm -f $ned0_log
     !$queues && echo -n en || echo -n dis; echo abled
@@ -28,19 +64,6 @@
     !tail -F $ned0_log
     -Commit queues are $neg_qtest
 [shell ncs-cli]
-    [invoke prepare-xmnr $queues]
-    !config dhcp defaultLeaseTime 200s
-    !commit
-    ???Commit complete.
-    !drned-xmnr state record-state state-name time format c-style overwrite true
-    ???success
-    !drned-xmnr state record-state state-name time
-    ???failure state time already exists
-    ~drned-xmnr state import-state-files
-    ! file-path-pattern ../subnet.xml merge false overwrite true
-    ???success
-    !drned-xmnr state check-states validate true
-    ???success all states are consistent
     [invoke test-walk-states "empty subnet time"]
 [shell os]
     """?
@@ -52,6 +75,7 @@
     ?====* 1 passed, .* ====*
     ~$_CTRL_C_
     ?SH-PROMPT:
+[shell ncs-cli]
     [endloop]
 
 [cleanup]

--- a/test/lux/common.luxinc
+++ b/test/lux/common.luxinc
@@ -45,7 +45,7 @@
         Test transition to $state
            load $state
            commit
-               succeeded
+               (succeeded|\(no modifications\))
            compare config
                succeeded
         """

--- a/test/lux/subnet2.xml
+++ b/test/lux/subnet2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<dhcp xmlns="http://tail-f.com/ns/example/dhcpd">
+  <SharedNetworks>
+    <sharedNetwork>
+      <name>test2</name>
+      <SubNets>
+        <subNet>
+          <net>2.2.2.2</net>
+          <mask>255.255.255.0</mask>
+        </subNet>
+      </SubNets>
+    </sharedNetwork>
+  </SharedNetworks>
+</dhcp>


### PR DESCRIPTION
State file discovery now takes into account also files that do not contain `".state."` in their name - enough if it ends with `.xml` or `.cfg`. Copying file like `ABC.xml` to a state directory that already contains `ABC.state.xml` leads to somewhat unpredictable behavior.