### PR TITLE
walk-states now works with file sets, fixes #30

### DIFF
--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -5,6 +5,7 @@
 [global ned0_log=$ned0_dir/test/output.log]
 
 [macro run-queues queues]
+    [my shell=$LUX_SHELLNAME]
 [shell ncs-cli]
     [invoke prepare-xmnr $queues]
 [shell os]
@@ -29,9 +30,11 @@
     ?====* 1 passed, .* ====*
     ~$_CTRL_C_
     ?SH-PROMPT:
+[shell $shell]
 [endmacro]
 
 [macro check-states states]
+    [my shell=$LUX_SHELLNAME]
 [shell os]
     ~netconf-console --get -x /devices/device/drned-xmnr/state/states |
     ~sed -n 's%.*<state>\(.*\)</state>.*%\1%p' |
@@ -41,6 +44,7 @@
     $states$$
     SH-PROMPT
     """
+[shell $shell]
 [endmacro]
 
 [shell os]
@@ -78,20 +82,40 @@
     !drned-xmnr state record-state state-name subnet2
     ???failure state subnet2 already exists
     [invoke check-states "dhcp-ls empty subnet subnet2 time"]
-[shell ncs-cli]
     !drned-xmnr state check-states validate true
     ???success all states are consistent
 
     [loop queues true false]
         [invoke run-queues $queues]
     [endloop]
-[shell ncs-cli]
     [progress deleting states]
     !drned-xmnr state delete-state state-name dhcp-ls
     ?success Deleted: dhcp-ls$
     !drned-xmnr state delete-state state-name-pattern subnet*
     ?success Deleted: (subnet, subnet2|subnet2, subnet)$
     [invoke check-states "empty time"]
+    !drned-xmnr state delete-state state-name time
+    ?success Deleted: time$
+    [progress walk-state with sets]
+    !config dhcp default-lease-time 300s
+    !commit
+    ?Commit complete
+    !drned-xmnr state record-state state-name lt:3
+    ?success
+    !config dhcp default-lease-time 400s
+    !commit
+    ?Commit complete
+    !drned-xmnr state record-state state-name lt:4
+    ?success
+    !drned-xmnr transitions walk-states | include "Test transition" | linnum
+    [timeout 10]
+    -3: Test transition
+    """?
+    1: Test transition to (empty|lt:[*])
+    2: Test transition to (empty|lt:[*])
+    admin@ncs\(.*\)\#
+    """
+    [timeout]
 
 [cleanup]
     [invoke cleanup]

--- a/test/lux/common.luxinc
+++ b/test/lux/common.luxinc
@@ -105,4 +105,6 @@
     ?SH-PROMPT:
     !rm -rf packages/*
     ?SH-PROMPT:
+    !rm -rf /tmp/xmnr
+    ?SH-PROMPT:
 [endmacro]


### PR DESCRIPTION
If the user does not provide its own set of states, the action walk-states
makes sure that one file set is represented by only one state.

As a result, the walk-states action output would look like

```
admin@ncs(config-device-dhcp0)# drned-xmnr transitions walk-states 
Prepare the device
Test transition to sbnet:*
Test transition to empty
Device cleanup
success Completed successfully
admin@ncs(config-device-dhcp0)# 
```