### PR TITLE
initial sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,11 @@ package. Using the tool's actions you can:
 
 ## Prerequisites
 
-The tool is supported to run on Python 3.5 or newer.  It is known to run on
-Python 2.7, but this is no longer actively maintained.
+The tool is supported to run on Python 3.5 or newer.
 
-Apart form that, several Python packages are needed: `pytest`, `pexpect`, and
-`lxml`; `pytest` version needs to be at least 3.0.  There are several options
-how to install these packages:
+Several Python packages are needed: `pytest`, `pexpect`, and `lxml`; `pytest`
+version needs to be at least 3.0.  There are several options how to install
+these packages:
 
 1. Quite likely, they are available in your system distribution repositories,
    for example in Ubuntu they can be installed like

--- a/package-meta-data.xml
+++ b/package-meta-data.xml
@@ -4,6 +4,12 @@
   <description>DrNED Examiner is a tool for examining/diagnosing your NEDs</description>
   <ncs-min-version>4.1</ncs-min-version>
   <component>
+    <name>drned_xmnr_check</name>
+    <application>
+      <python-class-name>drned_xmnr.check_action.XmnrCheck</python-class-name>
+    </application>
+  </component>
+  <component>
     <name>drned_xmnr</name>
     <application>
       <python-class-name>drned_xmnr.action.Xmnr</python-class-name>

--- a/python/drned_xmnr/check_action.py
+++ b/python/drned_xmnr/check_action.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import importlib
+
+from ncs import application
+
+REQ_GE = '>='
+
+REQ_DEFAULTS = [
+    ('pexpect', None),
+    ('pytest', (3, 0)),
+    ('lxml', None)]
+
+
+class XmnrCheckException(Exception):
+    pass
+
+
+def parse_version(verstr):
+    return [int(vnum) for vnum in verstr.split('.')]
+
+
+class XmnrCheck(application.Application):
+    def setup(self):
+        if sys.version_info < (3, 5):
+            raise XmnrCheckException('Required Python 3.5 or newer')
+        for (package, version) in self.xmnr_requirements():
+            try:
+                mod = importlib.import_module(package)
+            except ModuleNotFoundError:
+                errmsg = 'XMNR cannot run without the package {}'.format(package)
+                raise XmnrCheckException(errmsg)
+            if version is not None:
+                imported_version = parse_version(mod.__version__)
+                if imported_version < version:
+                    version_str = '.'.join(map(str, version))
+                    raise XmnrCheckException('Required {}>={}'.format(package, version_str))
+
+    def xmnr_requirements(self):
+        base = os.path.realpath(os.path.dirname(__file__))
+        pkg_path = os.path.dirname(os.path.dirname(base))
+        try:
+            with open(os.path.join(pkg_path, 'requirements.txt')) as reqs:
+                for req_line in reqs:
+                    req = req_line[:-1]
+                    # only REQ_GE supported
+                    if REQ_GE in req:
+                        [pkg, verstr] = req.split(REQ_GE)
+                        yield pkg, parse_version(verstr)
+                    else:
+                        yield req, None
+        except FileNotFoundError:
+            self.log.info('no requirements file found at {}, using defaults'.format(base))
+            return REQ_DEFAULTS

--- a/test/unit/test_check.py
+++ b/test/unit/test_check.py
@@ -1,0 +1,54 @@
+import sys
+from pytest import fixture, raises
+from drned_xmnr.check_action import XmnrCheck, XmnrCheckException
+from unittest.mock import patch
+
+
+@fixture
+def bad_py_version():
+    with patch('sys.version_info', new=(3, 4)):
+        yield
+
+
+class ImportMock:
+    """Pretend to either fail the import or import an old version.
+    """
+    def __init__(self, fail, modname='pytest'):
+        self.fail = fail
+        self.modname = modname
+        self.__version__ = '2.5'
+
+    def __call__(self, modname):
+        if self.fail:
+            raise ModuleNotFoundError
+        if modname == self.modname:
+            return self
+
+
+@fixture
+def missing_package():
+    with patch('importlib.import_module', new=ImportMock(True)):
+        yield
+
+
+@fixture
+def old_package():
+    with patch('importlib.import_module', new=ImportMock(False)):
+        yield
+
+
+class TestChecks:
+    def test_version_check(self, bad_py_version):
+        with raises(XmnrCheckException, match='Required Python 3.5 or newer'):
+            XmnrCheck().setup()
+
+    def test_missing_package_check(self, missing_package):
+        with raises(XmnrCheckException, match='XMNR cannot run without'):
+            XmnrCheck().setup()
+
+    def test_old_package_check(self, old_package):
+        with raises(XmnrCheckException, match='Required pytest>=3.0'):
+            XmnrCheck().setup()
+
+    def test_succeed(self):
+        XmnrCheck().setup()


### PR DESCRIPTION
The new component does not do anything interesting, it just makes sure that the environment meets that:

* Python is at least 3.5
* the three packages can be imported and `pytest` is at least 3.0

Otherwise it fails the whole NCS package.