### PR TITLE
fixing Python 2.7 support

### DIFF
--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import shutil


### PR DESCRIPTION
Few changes needed to make XMNR run on Python 2.7 again.