### PR TITLE
Add optional timeouts to potentially long-running import and walk-states commands.

### DIFF
--- a/drned/drned/device.py
+++ b/drned/drned/device.py
@@ -11,7 +11,6 @@ import common.test_common as common
 import subprocess
 import tempfile
 import time
-import urllib
 from lxml import etree
 
 INDENT = "=" * 30 + " "
@@ -76,7 +75,7 @@ class Device(object):
         # Handle possible settings
         if use:
             for u in use:
-                var,val = u.split("=")
+                var, val = u.split("=")
                 assert hasattr(self, var)
                 if val == "True":
                     val = True
@@ -306,7 +305,6 @@ class Device(object):
         """
         self.trace(INDENT + inspect.stack()[0][3] + "(" + name + ")")
         rm = None
-        self.last_load = name
         if rename_device or ancient:
             suffix = "." + name.split(".")[-1]
             prefix = os.path.basename(name)
@@ -368,7 +366,6 @@ class Device(object):
         if banner:
             self.trace(INDENT + inspect.stack()[0][3] + "(" + name + ")")
         rm = None
-        self.last_load = name
         # Get possible load options from file
         path = self.rload_path
         if os.path.isfile("%s.load" % name):
@@ -536,10 +533,6 @@ class Device(object):
                           " %s %s" % (self.rollback_xml[id], xml))
         # Create dry-run files
         self.dry_run(fname="drned-work/drned-dry-run.txt", banner=False)
-        # Check dry-run timing
-        f = [self.last_load]
-        if xml and self.last_load and "logs/rollback" in self.last_load:
-            f = [xml, self.last_load]
         # Update dry-run log
         with open("drned-work/drned-dry-run.txt") as inf, \
              open("drned-work/drned-dry-run-all.txt", "a") as outf:
@@ -575,11 +568,6 @@ class Device(object):
         print("NOTE: Commit id: %s" % id)
         self.commit_id.append(id)
         self._set_rollback_xml(xml)
-
-        f = [self.last_load]
-        if xml and self.last_load and "logs/rollback" in self.last_load:
-            f = [xml, self.last_load]
-        self.last_load = None
 
         # Do disconnect to force reload of NED instance variables
         if self.reconnect_required:
@@ -656,8 +644,6 @@ class Device(object):
         else:
             self.rollback_id = None
             print("NOTE: No rollback since commit was empty")
-        self.last_load = None if not self.rollback_id \
-                         else "drned-ncs/logs/rollback%s" % self.rollback_id
         return self
 
     def rollback_compare(self, id=-1, dry_run=True):
@@ -808,12 +794,12 @@ class Device(object):
                             "for more input: '%s'\nPROMPT" % ncs_buf_raw)
         if echo:
             print(self.ncs_buf)
-        if expect_not != None:
+        if expect_not is not None:
             self.saw_not(expect_not)
         else:
             # Always use fixed set of error msgs if none given
             self.saw_not("((ERROR|[Ee]rror|[Ff]ailed|[Aa]borted):)|([Ee]rror when|[Ee]xternal error|[Ii]nternal error)")
-        if expect != None:
+        if expect is not None:
             self.saw(expect)
         return self
 

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -300,7 +300,8 @@ class ImportConvertCliFiles(ImportOp):
     def _init_params(self, params):
         super(ImportConvertCliFiles, self)._init_params(params)
         self.devcli = self.param_default(params, "cli_device", self.dev_name)
-        self.cli_timeout = params.timeout
+        self.device_timeout = params.device_timeout
+        self.import_timeout = params.import_timeout
 
     def cli_filter(self, msg):
         match = self.filterrx.match(msg)
@@ -321,11 +322,13 @@ class ImportConvertCliFiles(ImportOp):
     def perform(self):
         filenames, states, _ = self.verify_filenames()
         args = ['python', 'cli2netconf.py', self.dev_name, self.devcli,
-                '-t', str(self.cli_timeout)] + \
+                '-t', str(self.device_timeout)] + \
                [os.path.realpath(filename) for filename in filenames]
         workdir = 'drned-ncs'
         self.failures = []
         self.devcli_error = None
+
+        self.extend_timeout(self.import_timeout)
         result, _ = self.run_in_drned_env(args, timeout=120, NC_WORKDIR=workdir)
         if self.devcli_error is not None:
             raise ActionError('No device driver definition found')

--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -189,6 +189,7 @@ class WalkTransitionsOp(TransitionsOp):
         self.state_filenames = [self.state_name_to_filename(state)
                                 for state in pstates]
         self.rollback = params.rollback
+        self.timeout = params.timeout
 
     def filter_state_sets(self, states):
         """Filter out duplicate representatives of "state sets".
@@ -217,6 +218,7 @@ class WalkTransitionsOp(TransitionsOp):
         # if rollback is not desired, we need to set it to an empty list
         fname_args = ["--fname=" + filename for filename in self.state_filenames]
         end_op = [] if self.rollback else ["--end-op", ""]
+        self.extend_timeout(self.timeout)
         result, _ = self.drned_run(fname_args + end_op +
                                    ["--ordered=false", "-k", "test_template_set"])
         self.log.debug("DrNED completed: {0}".format(result))

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -265,10 +265,16 @@ module drned-xmnr {
               type boolean;
               default false;
             }
-            leaf timeout {
+            leaf device-timeout {
               tailf:info
                 "How long should XMNR wait for a device to respond (or
                  how long to wait for an expected response).";
+              type uint16;
+              default 120;
+            }
+            leaf import-timeout {
+              tailf:info
+                "How long should NSO wait for the import command to complete.";
               type uint16;
               default 120;
             }
@@ -368,6 +374,12 @@ module drned-xmnr {
                  performed to the original state.";
               type boolean;
               default false;
+            }
+            leaf timeout {
+              tailf:info
+                "How long should NSO wait for the walk-states command to complete.";
+              type uint16;
+              default 120;
             }
           }
           output {

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -70,9 +70,27 @@
     !drned-xmnr state record-state state-name subnet2
     ???failure state subnet2 already exists
     [invoke check-states "dhcp-ls empty subnet subnet2 time"]
+    [progress validate states]
     !drned-xmnr state check-states validate true
     ???success all states are consistent
-
+    ?
+    [progress view states]
+    !drned-xmnr state view-state state-name dhcp-ls
+    """?
+    drned-xmnr state view-state state-name dhcp-ls
+    success <config xmlns="http://tail-f.com/ns/config/1.0">
+      <devices xmlns="http://tail-f.com/ns/ncs">
+      <device>
+        <name>ned0</name>
+          <config>
+            <dhcp xmlns="http://tail-f.com/ns/example/dhcpd">
+              <default-lease-time>PT200S</default-lease-time>
+            </dhcp>
+          </config>
+      </device>
+      </devices>
+    </config>
+    """
     [loop queues true false]
         [invoke run-queues $queues]
     [endloop]


### PR DESCRIPTION
Add optional timeouts to potentially long-running import and walk-states commands.

(Also, add missing view-state test-case and remove some dead code)

Signed-off-by: Jonas Johansson <jojohans@cisco.com>