### PR TITLE
support for ctrl-c abort

### DIFF
--- a/drned/common/test_template.py
+++ b/drned/common/test_template.py
@@ -274,6 +274,9 @@ def _drned_single_set(device, init, fname, init_op, op, end_op, it, ordered):
             # Use the file function also for rollbacks
             _drned_single_file(device, None, the_end,
                                commit_id_base=commit_id_base)
+        except KeyboardInterrupt:
+            # do not intercept CTRL-C
+            raise
         except BaseException:
             # Record the failed state and, if this is not the last
             # state in the list, restore the device to its original

--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -97,12 +97,12 @@ class SetupOp(base_op.ActionBase):
 
     def setup_drned(self):
         env = self.run_with_trans(self.setup_drned_env)
-        proc = subprocess.Popen(['make', 'env.sh'],
-                                env=env,
-                                cwd=self.drned_run_directory,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT)
-        result, _ = self.proc_run(proc, base_op.Progressor(self).progress, 120)
+        self.drned_process = subprocess.Popen(['make', 'env.sh'],
+                                              env=env,
+                                              cwd=self.drned_run_directory,
+                                              stdout=subprocess.PIPE,
+                                              stderr=subprocess.STDOUT)
+        result, _ = self.proc_run(lambda *ignore: None, 120)
         if result != 0:
             raise ActionError("Failed to set up env.sh for DrNED")
         self.cfg_file = os.path.join(self.drned_run_directory, self.dev_name + '.cfg')

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -98,6 +98,13 @@ module drned-xmnr {
 
   augment /ncs:devices/ncs:device {
     container drned-xmnr {
+      leaf cleanup-timeout {
+        type uint16;
+        default 5;
+        tailf:info
+          "How long should XMNR wait for a test to do clean-up in case
+           of an action abort.";
+      }
       container setup {
         tailf:action setup-xmnr {
           tailf:info

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -123,5 +123,39 @@
     """
     [timeout]
 
+    [progress aborting transitions]
+[shell os]
+    !tail -f $ned0_log
+[shell ncs-cli]
+    [timeout 5]
+    !drned-xmnr transitions walk-states
+    ?Test transition
+    ~$_CTRL_C_
+    ?Aborted
+    ???admin@ncs(config-config)
+[shell os]
+    ?walk states
+    ?KeyboardInterrupt
+[shell ncs-cli]
+    !drned-xmnr transitions explore-transitions
+    ?load
+    ~$_CTRL_C_
+    ?Aborted
+[shell os]
+    ?explore transitions
+    ?KeyboardInterrupt
+[shell ncs-cli]
+    !drned-xmnr transitions explore-transitions
+    ?Transition 1/.
+    ?commit
+    ~$_CTRL_C_
+    ?Aborted
+    [timeout]
+[shell os]
+    ?explore transitions
+    ?KeyboardInterrupt
+    ~$_CTRL_C_
+    ?SH-PROMPT
+
 [cleanup]
     [invoke cleanup]


### PR DESCRIPTION
Implementation of the `abort` callback; it first sets a `aborted` flag, then sends ctrl-c to the running pytest process, then kills it if it does not terminate within given period.