### PR TITLE
import and convert failure message improvement

### DIFF
--- a/python/drned_xmnr/op/filtering/events.py
+++ b/python/drned_xmnr/op/filtering/events.py
@@ -319,7 +319,7 @@ def event_generator(consumer):
                 consumer.send(DrnedCommitNNEvent())
             elif match.lastgroup == 'commit_result':
                 consumer.send(DrnedCommitResultEvent(match.string,
-                                                match.groupdict()['result'] == 'completed'))
+                                                     match.groupdict()['result'] == 'completed'))
             elif match.lastgroup == 'commit_complete':
                 consumer.send(DrnedCommitCompleteEvent(match.string))
             elif match.lastgroup == 'failure_reason':


### PR DESCRIPTION
* minor changes in import failures - improved incomprehensible messages in case of bad file format
* larger changes in convert: yet another message filtering mechanism (but much simpler than for transitions) to yield better output

May need some work to coordinate with the load-default branch.