### PR TITLE
states properly imported continuously

### DIFF
--- a/drned-skeleton/cli2netconf.py
+++ b/drned-skeleton/cli2netconf.py
@@ -228,6 +228,7 @@ def group_cli2netconf(device, devcli, group):
             device.sync_from()
             raise
         device.save(target, fmt="xml")
+        print("converted", desc.fname, 'to', target)
 
 
 def _cli2netconf(device, devcli, fnames):
@@ -240,6 +241,9 @@ def _cli2netconf(device, devcli, fnames):
         groupname = sgroup[0].fset
         try:
             group_cli2netconf(device, devcli, sgroup)
+        except KeyboardInterrupt:
+            print('Keyboard interrupt, abort')
+            raise
         except BaseException as e:
             print('failed to convert group', groupname)
             print('exception:', e)

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -124,5 +124,23 @@
     ???success Imported states: short-rad2:1, short-rad2:2
     [timeout]
 
+    !drned-xmnr state delete-state state-name-pattern *
+    !drned-xmnr state import-convert-cli-files file-path-pattern ../cfgs/*rad*.cfg
+    [timeout 10]
+    ?importing state short-rad1:1
+    [timeout]
+    ~$_CTRL_C_
+    ?Aborted: by user
+    !do show devices device cisco-nc0 drned-xmnr state states | sort-by state
+    """?
+    STATE *
+    -----* *
+    rad1 *
+    rad2 *
+
+    admin@ncs.*
+    """
+
+
 [cleanup]
     [invoke cleanup]

--- a/test/unit/test_cli2netconf.py
+++ b/test/unit/test_cli2netconf.py
@@ -67,7 +67,7 @@ class ConvertPatch(object):
     creates a function wrapper, that creates a Devcli and XDevice mock
     (there is only one common for both classes).
     '''
-    
+
     def __init__(self, failures={'load': [], 'sync': []}):
         self.failures = failures
         self.attribute_name = None
@@ -142,6 +142,7 @@ class TestCli2Netconf(object):
                     assert 'sync' == calls.pop()
                     break
                 assert ('save', (target,), {'fmt': 'xml'}) == calls.pop()
+                assert 'converted {} to {}'.format(filename, target) == prints.pop()
             assert 'clean_config' == calls.pop()
         assert ['sync'] == calls
 


### PR DESCRIPTION
When a conversion of one state is completed, the state is immediately added to the device states, so that if the action crashes or is aborted, the states converted before the crash stay available.