### PR TITLE
smarter passing of parameters to devcli

### DIFF
--- a/drned-skeleton/load-default-config.py
+++ b/drned-skeleton/load-default-config.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
 
 from contextlib import closing
-import sys
 
-from devcli import Devcli, XDevice, devcli_init_dirs
+from devcli import Devcli, XDevice
 
 
 def _load_default_config(nso_device, target_device):
@@ -11,35 +10,22 @@ def _load_default_config(nso_device, target_device):
     nso_device.sync_from()
 
 
-def load_default_config(dev_name, driver, timeout, *args):
-    workdir = devcli_init_dirs()
-
-    def init_nso_dev():
-        return closing(XDevice(dev_name))
-
+def load_default_config(nsargs):
     def init_cli_dev():
-        return closing(Devcli(driver, workdir, int(timeout)))
+        return closing(Devcli(nsargs))
 
-    with init_nso_dev() as nso_device, init_cli_dev() as target_device:
+    def init_nso_dev(devcli):
+        return closing(XDevice(devcli.devname))
+
+    with init_cli_dev() as target_device, \
+            init_nso_dev(target_device) as nso_device:
         _load_default_config(nso_device, target_device)
 
 
-# Usage: load-default-config.py netconf-device driver file-path
+# Usage: load-default-config.py [Devcli options]
 #
-#  - device-name: device name; the device must be configured by DrNED/XMNR
-#  - driver: device driver script to be executed to do the config reload
-#  - timeout: operation execution time limit to perform the request
-#
-#  First, the CLI device driver in the form <name>.py is looked up:
-#
-#  * in the first file's directory
-#  * its device/ subdirectory
-#  * in the current directory
-#  * in its device/ subdirectory
-#
-#  If one of the above succeeds, the driver is loaded. It then loads previously
-#  stored default configuration file on a device using it's native CLI,
-#  to return device to a default config state.
+#  run "load-default-config.py --help" to get more details
 
 if __name__ == "__main__":
-    load_default_config(*sys.argv[1:])
+    parser = Devcli.argparser()
+    load_default_config(parser.parse_args())

--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -340,7 +340,9 @@ class ActionBase(XmnrBase):
         root = maagic.get_root(trans)
         device_node = root.devices.device[self.dev_name]
         ip = device_node.address
-        port = device_node.port
+        port = device_node.drned_xmnr.cli_port
+        if port is None:
+            port = device_node.port
         driver = device_node.drned_xmnr.driver
         if driver is None:
             raise ActionError('device driver not configured, cannot continue')

--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -79,7 +79,6 @@ class XmnrBase(object):
             self.device_timeout = 120
         device_xmnr_node = device_node.drned_xmnr
         self.cleanup_timeout = device_xmnr_node.cleanup_timeout
-        self.driver = device_xmnr_node.driver
         try:
             os.makedirs(self.states_dir)
         except OSError:
@@ -320,6 +319,53 @@ class ActionBase(XmnrBase):
                 self.log.debug('found pytest executable: ' + executable)
                 return executable
         raise ActionError('PyTest not installed - pytest executable not found')
+
+    def get_authgroup_info(self, trans, root, locuser, authmap):
+        if authmap.same_user.exists():
+            username = locuser
+        else:
+            username = authmap.remote_name
+        if username is None:
+            return None, None
+        if authmap.same_pass.exists():
+            upwd = root.aaa.authentication.users.user[locuser].password
+        else:
+            upwd = authmap.remote_password
+        if upwd is None:
+            return username, None
+        trans.maapi.install_crypto_keys()
+        return username, _ncs.decrypt(upwd)
+
+    def get_devcli_params(self, trans):
+        root = maagic.get_root(trans)
+        device_node = root.devices.device[self.dev_name]
+        ip = device_node.address
+        port = device_node.port
+        driver = device_node.drned_xmnr.driver
+        if driver is None:
+            raise ActionError('device driver not configured, cannot continue')
+        authgroup_name = device_node.authgroup
+        authgroup = root.devices.authgroups.group[authgroup_name]
+        locuser = self.uinfo.username
+        if locuser in authgroup.umap:
+            authmap = authgroup.umap[locuser]
+        else:
+            authmap = authgroup.default_map
+        user, passwd = self.get_authgroup_info(trans, root, locuser, authmap)
+        return driver, user, passwd, ip, port
+
+    def devcli_run(self, script, script_args):
+        driver, username, passwd, ip, port = self.run_with_trans(self.get_devcli_params)
+        args = ['python', script, '--devname', self.dev_name,
+                '--driver', driver,
+                '--ip', ip, '--port', str(port),
+                '--workdir', 'drned-ncs', '--timeout', str(self.device_timeout)]
+        if username is not None:
+            args.extend(['--username', username])
+            if passwd is not None:
+                args.extend(['--password', passwd])
+        args.extend(script_args)
+        return self.run_in_drned_env(args)
 
     def run_in_drned_env(self, args, **envdict):
         env = self.run_with_trans(self.setup_drned_env)

--- a/python/drned_xmnr/op/common_op.py
+++ b/python/drned_xmnr/op/common_op.py
@@ -12,15 +12,8 @@ class LoadDefaultConfigOp(ActionBase):
     action_name = 'xmnr load-default-config'
 
     def perform(self):
-        args = [
-            'python', 'load-default-config.py',
-            self.dev_name, self.driver, str(self.device_timeout)
-        ]
-        workdir = 'drned-ncs'
-
         try:
-            self.run_in_drned_env(args, timeout=self.device_timeout,
-                                  NC_WORKDIR=workdir)
+            self.devcli_run('load-default-config.py', [])
         except BaseException as e:
             self.log.debug("Exception: " + repr(e))
             raise ActionError('Failed to load default configuration!')

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -355,14 +355,9 @@ class ImportConvertCliFiles(ImportOp):
 
     def perform(self):
         filenames, states, _ = self.verify_filenames()
-        if self.driver is None:
-            raise ActionError('device driver not configured, cannot continue')
-        args = ['python', 'cli2netconf.py', self.dev_name, self.driver,
-                '-t', str(self.device_timeout)] + \
-               [os.path.realpath(filename) for filename in filenames]
+        files = [os.path.realpath(filename) for filename in filenames]
         self.filter = ConvertFilter(self)
-
-        result, _ = self.run_in_drned_env(args, NC_WORKDIR=self.NC_WORKDIR)
+        result, _ = self.devcli_run('cli2netconf.py', files)
         if self.filter.devcli_error is not None:
             raise ActionError('Problems with the device driver: ' + self.filter.devcli_error)
         if result != 0 and not self.filter.failures:

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -146,6 +146,13 @@ module drned-xmnr {
           "Absolute filesystem path to a file of the device driver
            implementation to service the device-dependent DrNED XMNR actions.";
       }
+      leaf cli-port {
+        type uint16;
+        tailf:info
+          "Device CLI port number to be passed to the device driver;
+           if not set, the NETCONF device port number from the NSO
+           device configuration is passed instead.";
+      }
       container setup {
         tailf:action setup-xmnr {
           tailf:info

--- a/test/lux/cfgs/device/netsim_I.py
+++ b/test/lux/cfgs/device/netsim_I.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 def _get_data(devcli):
@@ -12,25 +11,31 @@ class Devcfg(object):
         self.path = path
         self.name = name
 
-    def _get(self, what):
-        with open(os.path.join(self.path, self.name + ".cfg")) as f:
-            m = re.search(what, f.read(), re.MULTILINE)
-        return m.group(1)
+    def init_params(self, devname='netsim0',
+                    ip='127.0.0.1', port=12022,
+                    username='admin', password='admin',
+                    **args):
+        self.devname = devname
+        self.ip = ip
+        self.port = port - 2000
+        self.username = username
+        self.password = password
+        self.prompt = "{}[(].+[)]# ?$".format(self.devname)
 
     def get_address(self):
-        return '127.0.0.1'
+        return self.ip
 
     def get_port(self):
-        return '10022'
+        return self.port
 
     def get_username(self):
-        return 'admin'
+        return self.username
 
     def get_password(self):
-        return 'admin'
+        return self.password
 
     def get_prompt(self):
-        return "^.*[(].+[)]# ?$"
+        return self.prompt
 
     def get_state_machine(self):
         return {

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -4,7 +4,7 @@
 
 [shell os]
     !readlink -f cfgs/device/*.py
-    ?(.*nc0.py)
+    ?(.*netsim_I.py)
     [global driver=$1]
     [invoke ned-test-setup]
     !ls -d $NCS_DIR/packages/neds/*-ios-cli* | tail -1
@@ -37,8 +37,14 @@
     ?success
     [timeout]
     [progress convert CLI config]
-    [local tweak=sed -e 's/10022/12022/' -e 's/cli>/netconf>/' -e 's/cisco-ios0/cisco-nc0/']
-    [invoke prepare-ncs-tweak cisco-ios0 $tweak cisco-nc0]
+[shell os]
+    !ncs-netsim add-to-network packages/cisco-ios 1 cisco-nc
+    [invoke shell-check]
+    !ncs-netsim start cisco-nc0
+    [invoke shell-check]
+[shell ncs-cli]
+    [local tweak=sed -e 's/10023/12023/' -e 's/cli>/netconf>/']
+    [invoke prepare-ncs-tweak cisco-nc0 $tweak cisco-nc0]
     !drned-xmnr driver $driver
     !commit
     !drned-xmnr setup setup-xmnr overwrite true

--- a/test/lux/etrafo/usr/device/netsim_J.py
+++ b/test/lux/etrafo/usr/device/netsim_J.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 def _get_data(devcli):
@@ -12,25 +11,31 @@ class Devcfg(object):
         self.path = path
         self.name = name
 
-    def _get(self, what):
-        with open(os.path.join(self.path, self.name + ".cfg")) as f:
-            m = re.search(what, f.read(), re.MULTILINE)
-        return m.group(1)
+    def init_params(self, devname='netsim0',
+                    ip='127.0.0.1', port=12022,
+                    username='admin', password='admin',
+                    **args):
+        self.devname = devname
+        self.ip = ip
+        self.port = port - 2000
+        self.username = username
+        self.password = password
+        self.prompt = "{}@{}%$".format(self.username, self.devname)
 
     def get_address(self):
-        return '127.0.0.1'
+        return self.ip
 
     def get_port(self):
-        return '10022'
+        return self.port
 
     def get_username(self):
-        return 'admin'
+        return self.username
 
     def get_password(self):
-        return 'admin'
+        return self.password
 
     def get_prompt(self):
-        return "admin@etrafo0%$"
+        return self.prompt
 
     def get_state_machine(self):
         return {

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -17,7 +17,7 @@
 [shell os]
     [invoke econfd-check]
     !readlink -f etrafo/usr/device/*.py
-    ?(.*etrafo0.py)
+    ?[^/]*(/.*netsim_J.py)
     [global driver=$1]
     [invoke ned-test-setup]
     !ncs-make-package --no-java --netconf-ned ../../etrafo etrafo

--- a/test/unit/mocklib.py
+++ b/test/unit/mocklib.py
@@ -80,14 +80,21 @@ XMNR_INSTALL = 'xmnr-install'
 
 @contextmanager
 def ncs_mock():
-    device = Mock(device_type=Mock(ne_type='netconf', netconf='netconf'), read_timeout=None)
-    rootmock = Mock(devices=Mock(device={DEVICE_NAME: device}),
+    nonex = Mock(exists=lambda:False)
+    device = Mock(device_type=Mock(ne_type='netconf', netconf='netconf'),
+                  read_timeout=None, address='1.2.3.4', port='5555', authgroup='default')
+    authgrp = Mock(default_map=Mock(remote_name='admin', remote_password='admin',
+                                    same_name=nonex, same_pass=nonex),
+                   umap={})
+    rootmock = Mock(devices=Mock(device={DEVICE_NAME: device},
+                                 authgroups=Mock(group={'default': authgrp})),
                     packages=Mock(package={'drned-xmnr': Mock(directory=XMNR_INSTALL)}),
                     drned_xmnr=Mock(xmnr_directory=XMNR_DIRECTORY,
                                     drned_directory=DRNED_DIRECTORY,
                                     log_detail=Mock(cli='all', redirect=None),
                                     xmnr_log_file=None))
-    ncs_items = ['_ncs.stream_connect', '_ncs.dp.action_set_timeout', '_ncs.maapi.cli_write']
+    ncs_items = ['_ncs.stream_connect', '_ncs.dp.action_set_timeout', '_ncs.maapi.cli_write',
+                 '_ncs.decrypt']
     maapi_inst = MaapiMock()
     with patch('ncs.maapi.Maapi', return_value=maapi_inst):
         with patch('ncs.maagic.get_root', return_value=rootmock):

--- a/test/unit/test_cli2netconf.py
+++ b/test/unit/test_cli2netconf.py
@@ -1,4 +1,5 @@
 import operator
+import collections
 import os
 import random
 from six import functools
@@ -17,8 +18,9 @@ class MockDevcli(object):
         self.methods = {'save_config', 'clean_config',
                         'clean', 'save'}
 
-    def inst_init(self, driver, workdir, timeout):
-        self.workdir = workdir
+    def inst_init(self, argsns):
+        self.workdir = argsns.workdir
+        self.devname = argsns.devname
 
     def load_config(self, filename):
         self.gen_method('load', filename)
@@ -108,6 +110,10 @@ class ConvertPatch(object):
         self.print_caps.append(' '.join(map(str, args)))
 
 
+ArgsNS = collections.namedtuple('ArgsNS',
+                                ['devname', 'driver', 'workdir', 'ip', 'port', 'timeout', 'files'])
+
+
 class TestCli2Netconf(object):
     groups = [['f1.cfg'], ['f2:1.cfg', 'f2:2.cfg'], ['f3.cfg']]
 
@@ -118,7 +124,8 @@ class TestCli2Netconf(object):
 
     def run_convert_test(self, patcher):
         files = self.config_files()
-        cli2netconf.cli2netconf('mock-dev', 'mock-cli-dev', *files)
+        cli2netconf.cli2netconf(ArgsNS('mockdevice', '/tmp/driver', '/',
+                                       '1.2.3.4', 5555, 120, files))
         calls = list(reversed(patcher.devclimock.device_calls))
         prints = list(reversed(patcher.print_caps))
         assert 'save_config' == calls.pop()


### PR DESCRIPTION
XMNR sends a set of device parameters down to devcli which makes them available to device drivers, so that it is not necessary to modify the driver/its .cfg file each time it is used with a new device of the same type.