### PR TITLE
new skip-existing parameter for import-state-files

### DIFF
--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -168,7 +168,7 @@ class ImportOp(ConfigOp):
         conflicts = {self.state_filename_to_name(filename) for filename in checks
                      if filename is not None}
         if conflicts and not self.overwrite and not self.skip_existing:
-                raise ActionError("States already exist: " + ", ".join(conflicts))
+            raise ActionError("States already exist: " + ", ".join(conflicts))
         return filenames, states, conflicts
 
     def get_state_name(self, origname):
@@ -361,10 +361,10 @@ class ImportConvertCliFiles(ImportOp):
             raise ActionError('device driver not configured, cannot continue')
 
         if conflicts and not self.overwrite and self.skip_existing:
-            filenames = [ v for i,v in enumerate(filenames) if states[i] in conflicts ]
-            if len(filenames) < 1:
+            filenames = [v for i, v in enumerate(filenames) if states[i] not in conflicts]
+            if not filenames:
                 raise ActionError('No new states to import')
-            states = [ state for state in states if state not in conflicts ]
+            states = [state for state in states if state not in conflicts]
 
         args = ['python', 'cli2netconf.py', self.dev_name, self.driver,
                 '-t', str(self.device_timeout)] + \

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -275,9 +275,19 @@ module drned-xmnr {
             leaf target-format {
               type state-file-format;
             }
-            leaf overwrite {
-              type boolean;
-              default false;
+            choice conflicts {
+              default overwrite;
+              case overwrite {
+                leaf overwrite {
+                  type boolean;
+                  default false;
+                }
+              }
+              case skip-existing {
+                leaf skip-existing {
+                  type empty;
+                }
+              }
             }
             leaf merge {
               tailf:info "Merge the file(s) with the current configuration

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -312,9 +312,19 @@ module drned-xmnr {
               type filepath-pattern-type;
               mandatory true;
             }
-            leaf overwrite {
-              type boolean;
-              default false;
+            choice conflicts {
+              default overwrite;
+              case overwrite {
+                leaf overwrite {
+                  type boolean;
+                  default false;
+                }
+              }
+              case skip-existing {
+                leaf skip-existing {
+                  type empty;
+                }
+              }
             }
           }
           output {

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -23,6 +23,23 @@ module drned-xmnr {
     }
   }
 
+  grouping conflicts-resolution-choice {
+    choice conflicts {
+      default overwrite;
+      case overwrite {
+        leaf overwrite {
+          type boolean;
+          default false;
+        }
+      }
+      case skip-existing {
+        leaf skip-existing {
+          type empty;
+        }
+      }
+    }
+  }
+
   typedef filepath-pattern-type {
     type string;
   }
@@ -275,20 +292,7 @@ module drned-xmnr {
             leaf target-format {
               type state-file-format;
             }
-            choice conflicts {
-              default overwrite;
-              case overwrite {
-                leaf overwrite {
-                  type boolean;
-                  default false;
-                }
-              }
-              case skip-existing {
-                leaf skip-existing {
-                  type empty;
-                }
-              }
-            }
+            uses conflicts-resolution-choice;
             leaf merge {
               tailf:info "Merge the file(s) with the current configuration
                           before creating the XMNR state file.";
@@ -312,20 +316,7 @@ module drned-xmnr {
               type filepath-pattern-type;
               mandatory true;
             }
-            choice conflicts {
-              default overwrite;
-              case overwrite {
-                leaf overwrite {
-                  type boolean;
-                  default false;
-                }
-              }
-              case skip-existing {
-                leaf skip-existing {
-                  type empty;
-                }
-              }
-            }
+            uses conflicts-resolution-choice;
           }
           output {
             uses action-output-common;

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -122,7 +122,7 @@
 [shell ncs-cli]
     !drned-xmnr state import-convert-cli-files file-path-pattern ../cfgs/short-rad2*.cfg
     -
-    ?failure States already exists: short-rad2:[12]
+    ?failure States already exist: short-rad2:[12]
     !drned-xmnr state import-convert-cli-files file-path-pattern ../cfgs/short-rad2*.cfg overwrite true
     [timeout 20]
     -failure

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -484,7 +484,7 @@ class TestStates(TestBase):
         with open(os.path.join(self.test_run_dir, state_path)) as state_data:
             assert state_data.read() == test_state_data_xml
 
-    def invoke_import_state_files(self, path, expected_success = True, **extra_action_params):
+    def invoke_import_state_files(self, path, expected_success=True, **extra_action_params):
         output = self.invoke_action('import-state-files',
                                     file_path_pattern=os.path.join(path, '*1.state.cfg'),
                                     format="c-style",
@@ -496,6 +496,8 @@ class TestStates(TestBase):
             self.check_output(output)
             states = sorted(state for state in self.states if state.endswith('1'))
             self.check_states(states)
+        else:
+            assert output.failure is not None or output.error is not None
         return states
 
     @xtest_patch
@@ -523,16 +525,16 @@ class TestStates(TestBase):
         LoadSaveConfig(xpatch.system, xpatch.ncs)
         # import first time into clean environment
         states = self.invoke_import_state_files(path)
-        assert states is not None
-        # try default import and fail
-        states = self.invoke_import_state_files(path, expected_success=False, skip_existing = True)
+        assert len(states) > 0
+        # try default import again and fail
+        states = self.invoke_import_state_files(path, expected_success=False)
         assert states is None
         # reimport with skipping already existing states
-        states = self.invoke_import_state_files(path, skip_existing = True)
-        assert states is not None
+        states = self.invoke_import_state_files(path, skip_existing=True)
+        assert len(states) > 0
         # reimport with overwrite
-        states = self.invoke_import_state_files(path, overwrite = True)
-        assert states is not None
+        states = self.invoke_import_state_files(path, overwrite=True)
+        assert len(states) > 0
 
     @xtest_patch
     def test_delete_states_pattern(self, xpatch):


### PR DESCRIPTION
add new parameter for import-state-files to allow continuation of previously interrupted run

Signed-off-by: Jozef Miklos <jomiklos@cisco.com>