### PR TITLE
better messages for SSH authentication failures

### DIFF
--- a/drned-skeleton/cli2netconf.py
+++ b/drned-skeleton/cli2netconf.py
@@ -8,7 +8,7 @@ import operator
 import os
 import re
 
-from devcli import Devcli, XDevice
+from devcli import Devcli, XDevice, devcli_init_dirs, DevcliAuthException
 
 
 testrx = re.compile(r'(?P<set>[^:.]*)(?::(?P<index>[0-9]+))?(?:\..*)?$')
@@ -56,6 +56,8 @@ def _cli2netconf(device, devcli, fnames):
         except KeyboardInterrupt:
             print('Keyboard interrupt, abort')
             raise
+        except DevcliAuthException:
+            raise
         except BaseException as e:
             print('failed to convert group', groupname)
             print('exception:', e)
@@ -65,9 +67,12 @@ def _cli2netconf(device, devcli, fnames):
 
 def cli2netconf(nsargs):
     fnames = nsargs.files
-    with closing(Devcli(nsargs)) as devcli, \
-            closing(XDevice(devcli.devname)) as device:
-        _cli2netconf(device, devcli, fnames)
+    try:
+        with closing(Devcli(nsargs)) as devcli, \
+                closing(XDevice(devcli.devname)) as device:
+            _cli2netconf(device, devcli, fnames)
+    except DevcliAuthException:
+        print('failed to authenticate')
 
 
 # Usage: cli2netconf.py [Devcli options] [files]

--- a/drned-skeleton/load-default-config.py
+++ b/drned-skeleton/load-default-config.py
@@ -2,12 +2,15 @@ from __future__ import print_function
 
 from contextlib import closing
 
-from devcli import Devcli, XDevice
+from devcli import Devcli, XDevice, DevcliAuthException
 
 
 def _load_default_config(nso_device, target_device):
-    target_device.restore_config()
-    nso_device.sync_from()
+    try:
+        target_device.restore_config()
+        nso_device.sync_from()
+    except DevcliAuthException:
+        print('failed to authenticate')
 
 
 def load_default_config(nsargs):

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -10,6 +10,7 @@ import _ncs
 
 from . import base_op
 from .ex import ActionError
+from .common_op import DevcliLogMatch
 
 
 state_metadata = """\
@@ -292,51 +293,38 @@ class ImportStateFiles(ImportOp):
                 state_data.write(data)
 
 
-class ConvertFilter(object):
-    filterexpr = (
+class ConvertMatch(DevcliLogMatch):
+    matchexpr = (
         r'(?:(?P<convert>converting [^ ]* to [^ ]*/(?P<cnvstate>[^/]*)[.]xml)'
         r'|(?P<converted>converted [^ ]* to (?P<target>[^ ]*/(?P<donestate>[^/]*)[.]xml))'
         r'|(?P<failure>failed to convert group (?P<group>.*))'
-        r'|(?P<devcli>.*DevcliException: No device definition found)'
-        r'|(?P<traceback>Traceback [(]most recent call last[)]:)'
         r'|(?P<format>Filename format not understood: (?P<filename>.*))'
-        r'|(?P<newstate>^STATE: (?P<state>[^ ]*) : .*)'
-        r'|(?P<match>^MATCHED \'(?P<matchstate>.*)\', SEND: .*)'
         r')$')
-    filterrx = re.compile(filterexpr)
+    matchrx = re.compile(matchexpr)
 
     def __init__(self, converter):
+        super(ConvertMatch, self).__init__()
         self.failures = []
-        self.devcli_error = None
         self.waitstate = None
         self.converter = converter
 
-    def process(self, msg):
-        match = self.filterrx.match(msg)
+    def match(self, msg):
+        report = super(ConvertMatch, self).match(msg)
+        if report is not None:
+            return report
+        match = ConvertMatch.matchrx.match(msg)
         if match is None:
-            return
+            return None
         gd = match.groupdict()
         if match.lastgroup == 'convert':
             return 'importing state ' + gd['cnvstate']
         elif match.lastgroup == 'converted':
             self.converter.complete_import(gd['target'], gd['donestate'])
             return None
-        elif match.lastgroup == 'devcli':
-            self.devcli_error = 'could not find the device driver definition'
-            return 'device driver not found'
         elif match.lastgroup == 'failure':
             group = gd['group']
             self.failures.append(group)
             return 'failed to import group ' + group
-        elif match.lastgroup == 'traceback':
-            self.devcli_error = 'the device driver appears to be broken'
-            return 'device driver failed'
-        elif match.lastgroup == 'newstate':
-            self.waitstate = gd['state']
-            return None
-        elif match.lastgroup == 'match':
-            self.waitstate = None
-            return None
         elif match.lastgroup == 'format':
             filename = gd['filename']
             msg = 'unknown filename format: {}; should be name[:index].ext'
@@ -350,15 +338,18 @@ class ImportConvertCliFiles(ImportOp):
 
     NC_WORKDIR = 'drned-ncs'
 
+    def __init__(self, *args):
+        super(ImportConvertCliFiles, self).__init__(*args)
+        self.filter = ConvertMatch(self)
+
     def cli_filter(self, msg):
-        report = self.filter.process(msg)
+        report = self.filter.match(msg)
         if report is not None:
             super(ImportConvertCliFiles, self).cli_filter(report + '\n')
 
     def perform(self):
         filenames, states, _ = self.verify_filenames()
         files = [os.path.realpath(filename) for filename in filenames]
-        self.filter = ConvertFilter(self)
         result, _ = self.devcli_run('cli2netconf.py', files)
         if self.filter.devcli_error is not None:
             raise ActionError('Problems with the device driver: ' + self.filter.devcli_error)

--- a/test/lux/cfgs/device/netsim_I.py
+++ b/test/lux/cfgs/device/netsim_I.py
@@ -41,6 +41,7 @@ class Devcfg(object):
         return {
             # After login
             "enter": [
+                ("Permission denied, please try again", None, "authfailed"),
                 ("[Pp]assword:", self.get_password(), "enter"),
                 ("^.*> $", "enable", "config")
             ],

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -4,8 +4,10 @@
 
 [shell os]
     !readlink -f cfgs/device/*.py
-    ?(.*netsim_I.py)
-    [global driver=$1]
+    ?(.*/)(netsim_I.py)
+    [global driverpath=$1]
+    [global driver=${1}${2}]
+    [global broken=${1}broken.py]
     [invoke ned-test-setup]
     !ls -d $NCS_DIR/packages/neds/*-ios-cli* | tail -1
     ?(cisco-ios.*)
@@ -152,6 +154,29 @@
     admin@ncs.*
     """
 
+    [progress auth failure message]
+[shell os]
+    # force the password to be "nimda" in the "broken" driver
+    !sed 's/self.password = .*/self.password = "nimda"/' $driver > $broken
+    [invoke shell-check]
+[shell ncs-cli]
+    !drned-xmnr driver $broken
+    !commit
+    [timeout 20]
+    !drned-xmnr state import-convert-cli-files file-path-pattern ../cfgs/rad1.cfg overwrite true
+    ?Failed to authenticate to the device CLI
+
 
 [cleanup]
+    !ncs_cli -u admin -C
+    ???admin@ncs#
+    !config
+    !devices device cisco-nc0 drned-xmnr driver $driver
+    !commit
+    ?Commit complete|No modifications
+    !end
+    !exit
+    ?SH-PROMPT:
+    !rm -f $broken
+    ?SH-PROMPT:
     [invoke cleanup]


### PR DESCRIPTION
Devcli now supports a new driver state "authfailed" - if the driver enters the state, Devcli immediately raises an exception which is subsequently spotted by XMNR itself and a corresponding message is displayed to the user. Devcli filtering was slightly refactored and applied also to the load-default action.
