### PR TITLE
support for ignored and disabled states

### DIFF
--- a/python/drned_xmnr/action.py
+++ b/python/drned_xmnr/action.py
@@ -33,6 +33,8 @@ class ActionHandler(dp.Action):
     handlers = {
         ns.ns.drned_xmnr_setup_xmnr_: setup_op.SetupOp,
         ns.ns.drned_xmnr_delete_state_: config_op.DeleteStateOp,
+        ns.ns.drned_xmnr_disable_state_: config_op.DisableStateOp,
+        ns.ns.drned_xmnr_enable_state_: config_op.EnableStateOp,
         ns.ns.drned_xmnr_list_states_: config_op.ListStatesOp,
         ns.ns.drned_xmnr_view_state_: config_op.ViewStateOp,
         ns.ns.drned_xmnr_record_state_: config_op.RecordStateOp,

--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -58,6 +58,8 @@ all three layers with increasing margin:
 class XmnrBase(object):
     xml_statefile_extension = '.state.xml'
     cfg_statefile_extension = '.state.cfg'
+    metadata_extension = '.load'
+    flag_file_extension = '.disabled'
     xml_extensions = [xml_statefile_extension, '.xml']
     cfg_extensions = [cfg_statefile_extension, '.cfg']
 
@@ -129,6 +131,13 @@ class XmnrBase(object):
 
     def get_state_files(self):
         return self.get_state_files_by_pattern('*')
+
+    def get_disabled_state_files(self):
+        return [filename for filename in self.get_state_files()
+                if os.path.exists(filename + self.flag_file_extension)]
+
+    def is_state_disabled(self, state):
+        return os.path.exists(self.state_name_to_filename(state) + self.flag_file_extension)
 
     def get_state_files_by_pattern(self, pattern):
         files = {}

--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -156,7 +156,8 @@ class StatesTransitionsOp(TransitionsOp):
         states = list(params.states)
         if states == []:
             states = [state for state in self.get_states()
-                      if state not in params.ignore_states]
+                      if state not in params.ignore_states
+                      and not self.is_state_disabled(state)]
             states = self.filter_states(states)
             random.shuffle(states)
         else:

--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -143,20 +143,36 @@ class TransitionToStateOp(TransitionsOp):
             return {'failure': result}
 
 
-class ExploreTransitionsOp(TransitionsOp):
+class StatesTransitionsOp(TransitionsOp):
+    """Simple extension for transition operation involving multiple
+    states.  Adds support for retrieving the `transition-states`
+    grouping.
+    """
+
+    def filter_states(self, states):
+        return states
+
+    def get_transition_filenames(self, params):
+        states = list(params.states)
+        if states == []:
+            states = [state for state in self.get_states()
+                      if state not in params.ignore_states]
+            states = self.filter_states(states)
+            random.shuffle(states)
+        else:
+            states = self.filter_states(params.states)
+        self.state_filenames = [self.state_name_to_filename(state)
+                                for state in states]
+
+
+class ExploreTransitionsOp(StatesTransitionsOp):
     action_name = 'explore transitions'
 
     def event_processor(self, level, sink):
         return filtering.explore_output_filter(level, sink, self.event_context)
 
     def _init_params(self, params):
-        pstates = list(params.states)
-        if pstates == []:
-            self.state_filenames = self.get_state_files()
-            random.shuffle(self.state_filenames)
-        else:
-            self.state_filenames = [self.state_name_to_filename(state)
-                                    for state in pstates]
+        self.get_transition_filenames(params)
         stp = params.stop_after
         self.stop_time = 24 * int(self.param_default(stp, "days", 0))
         self.stop_time = 60 * int(self.param_default(stp, "hours", self.stop_time))
@@ -229,17 +245,15 @@ class ExploreTransitionsOp(TransitionsOp):
         return result
 
 
-class WalkTransitionsOp(TransitionsOp):
+class WalkTransitionsOp(StatesTransitionsOp):
     action_name = 'walk states'
 
     def _init_params(self, params):
-        pstates = list(params.states)
-        if pstates == []:
-            pstates = list(self.filter_state_sets(self.get_states()))
-            random.shuffle(pstates)
-        self.state_filenames = [self.state_name_to_filename(state)
-                                for state in pstates]
+        self.get_transition_filenames(params)
         self.rollback = params.rollback
+
+    def filter_states(self, states):
+        return list(self.filter_state_sets(states))
 
     def filter_state_sets(self, states):
         """Filter out duplicate representatives of "state sets".

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -195,12 +195,28 @@ module drned-xmnr {
         }
       }
       container state {
+        grouping state-or-pattern {
+          choice state-or-pattern {
+            mandatory true;
+            leaf state-name {
+              type leafref {
+                path ../../states/state;
+              }
+            }
+            leaf state-name-pattern {
+              type string;
+            }
+          }
+        }
         list states {
           config false;
           tailf:callpoint xmnr-states;
           key state;
           leaf state {
             type string;
+          }
+          leaf disabled {
+            type empty;
           }
         }
         tailf:action record-state {
@@ -240,17 +256,28 @@ module drned-xmnr {
           tailf:info "Delete a saved state file. ";
           tailf:actionpoint drned-xmnr;
           input {
-            choice delete-state {
-              mandatory true;
-              leaf state-name {
-                type leafref {
-                  path ../../states/state;
-                }
-              }
-              leaf state-name-pattern {
-                type string;
-              }
-            }
+            uses state-or-pattern;
+          }
+          output {
+            uses action-output-common;
+          }
+        }
+        tailf:action disable-state {
+          tailf:info "Disable a state so that `walk-states' or `explore-states'
+                      ignores it.";
+          tailf:actionpoint drned-xmnr;
+          input {
+            uses state-or-pattern;
+          }
+          output {
+            uses action-output-common;
+          }
+        }
+        tailf:action enable-state {
+          tailf:info "Enable a disabled state.";
+          tailf:actionpoint drned-xmnr;
+          input {
+            uses state-or-pattern;
           }
           output {
             uses action-output-common;

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -349,6 +349,28 @@ module drned-xmnr {
         }
       }
       container transitions {
+        grouping transition-states {
+          choice states-selection {
+            default states;
+            leaf-list states {
+              tailf:info
+                "List of states to pass through (in given order); if
+                 empty, all states in random order are used.";
+              ordered-by user;
+              type leafref {
+                path ../../../state/states/state;
+              }
+            }
+            leaf-list ignore-states {
+              tailf:info
+                "List of states to be ignored for transitions; if used, all
+                 states except these ones are used in a random order";
+              type leafref {
+                path ../../../state/states/state;
+              }
+            }
+          }
+        }
         tailf:action transition-to-state {
           tailf:info
             "Change the device state/configuration, possibly with
@@ -376,15 +398,7 @@ module drned-xmnr {
              set.";
           tailf:actionpoint drned-xmnr;
           input {
-            leaf-list states {
-              tailf:info
-                "List of states to pass through (in given order); if
-                 empty, all states in random order are used.";
-              ordered-by user;
-              type leafref {
-                path ../../../state/states/state;
-              }
-            }
+            uses transition-states;
             container stop-after {
               tailf:info "Do not start more transitions after given time/coverage has been reached.";
               choice unit-selection {
@@ -405,15 +419,7 @@ module drned-xmnr {
           tailf:info "Go through all states one after another.";
           tailf:actionpoint drned-xmnr;
           input {
-            leaf-list states {
-              tailf:info
-                "List of states to pass through (in given order); if
-                 empty, all states in random order are used.";
-              ordered-by user;
-              type leafref {
-                path ../../../state/states/state;
-              }
-            }
+            uses transition-states;
             leaf rollback {
               tailf:info
                 "If set to true, after each transition a rollback is

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -126,6 +126,31 @@
     """
     [timeout]
 
+    [progress disable/enable states]
+    !drned-xmnr state disable-state state-name-pattern lt:*
+    ?success
+    !drned-xmnr transitions walk-states | include "Test transition" | linnum
+    [timeout 10]
+    -2: Test transition
+    """?
+    1: Test transition to empty
+    admin@ncs\(.*\)\#
+    """
+    [timeout]
+    !drned-xmnr state enable-state state-name-pattern lt:[1-3]
+    ?success
+    [timeout 30]
+    !drned-xmnr transitions explore-transitions | include "Found|Starting with" | linnum
+    """?
+    1: Found 2 states .*
+    2: Starting with state (empty|lt:3)
+    3: Starting with state (empty|lt:3)
+    admin@ncs\(.*\)\#
+    """
+    [timeout]
+    !drned-xmnr state enable-state state-name-pattern *
+    ?success
+
     [progress aborting transitions]
 [shell os]
     !tail -f $ned0_log

--- a/test/lux/clined.lux
+++ b/test/lux/clined.lux
@@ -142,12 +142,22 @@
     [timeout]
     ~$_CTRL_C_
     ?Aborted: by user
-    !do show devices device cisco-nc0 drned-xmnr state states | sort-by state
+    !do show devices device cisco-nc0 drned-xmnr state states
     """?
-    STATE *
+    STATE *DISABLED *
     -----* *
-    rad1 *
-    rad2 *
+    rad1 *- *
+    rad2 *- *
+
+    admin@ncs.*
+    """
+    !drned-xmnr state disable-state state-name rad1
+    !do show devices device cisco-nc0 drned-xmnr state states 
+    """?
+    STATE *DISABLED *
+    -----* *
+    rad1 *X *
+    rad2 *- *
 
     admin@ncs.*
     """

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -77,14 +77,14 @@
     [timeout]
     !do show devices device etrafo0 drned-xmnr state states | sort-by state
     """?
-    STATE *
+    STATE *DISABLED *
     -----* *
-    empty *
-    usr01 *
-    usr02 *
-    usr04 *
-    usr05 *
-    usr06 *
+    empty *- *
+    usr01 *- *
+    usr02 *- *
+    usr04 *- *
+    usr05 *- *
+    usr06 *- *
 
     admin@ncs.*
     """


### PR DESCRIPTION
The change implements two new features:
* input parameter `ignore-states` for the actions "walk" and "explore"; it tells XMNR to walk/explore all (enabled) states except those to be ignored;
* two actions `disable-state` and `enable-state`; a disabled state is automatically ignored in the "walk" and "explore" actions, unless explicitly told otherwise.