### PR TITLE
watching for device timeout/disconnect in devcli

### DIFF
--- a/drned-skeleton/load-default-config.py
+++ b/drned-skeleton/load-default-config.py
@@ -1,16 +1,19 @@
 from __future__ import print_function
 
 from contextlib import closing
+import sys
 
-from devcli import Devcli, XDevice, DevcliAuthException
+from devcli import Devcli, XDevice, DevcliException
 
 
 def _load_default_config(nso_device, target_device):
     try:
         target_device.restore_config()
         nso_device.sync_from()
-    except DevcliAuthException:
-        print('failed to authenticate')
+    except DevcliException as e:
+        print()
+        print(e)
+        sys.exit(-1)
 
 
 def load_default_config(nsargs):

--- a/python/drned_xmnr/op/common_op.py
+++ b/python/drned_xmnr/op/common_op.py
@@ -19,6 +19,8 @@ class DevcliLogMatch(object):
         r'|(?P<traceback>Traceback [(]most recent call last[)]:)'
         r'|(?P<newstate>^STATE: (?P<state>[^ ]*) : .*)'
         r'|(?P<match>^MATCHED \'(?P<matchstate>.*)\', SEND: .*)'
+        r'|(?P<closed>device communication failure: .*EOF.*)'
+        r'|(?P<timeout>device communication failure: .*Timeout.*)'
         r'|(?P<authfailed>failed to authenticate)'
         r')$')
     matchrx = re.compile(matchexpr)
@@ -40,6 +42,12 @@ class DevcliLogMatch(object):
         elif match.lastgroup == 'match':
             self.waitstate = None
             return None
+        elif match.lastgroup == 'closed':
+            self.devcli_error = 'connection closed'
+            return 'Could not connect to the device or device connection closed'
+        elif match.lastgroup == 'timeout':
+            self.devcli_error = 'device communication timeout'
+            return 'Device communication timeout'
         elif match.lastgroup == 'authfailed':
             self.devcli_error = 'failed to authenticate'
             return 'Failed to authenticate to the device CLI'

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -38,8 +38,7 @@
     [my shell=$LUX_SHELLNAME]
 [shell os]
     ~netconf-console --get -x /devices/device/drned-xmnr/state/states |
-    ~sed -n 's%.*<state>\(.*\)</state>.*%\1%p' |
-    !sort | xargs echo
+    !sed -n 's%.*<state>\(.*\)</state>.*%\1%p' | xargs echo
     """?
     netconf-console --get .*
     $states$$

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -107,5 +107,22 @@
     admin@ncs.*
     """
 
+    [progress convert with a dead device]
+    !drned-xmnr state delete-state state-name-pattern *
+    ?Deleted: ((usr0[1-6]|empty),? *){5}
+    [timeout 40]
+    !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
+    [invoke suspend-for "importing state usr03" "Device communication timeout"]
+    [timeout]
+    !do show devices device etrafo0 drned-xmnr state states
+    """?
+    STATE *DISABLED *
+    -----* *
+    usr01 *- *
+    usr02 *- *
+
+    admin@ncs.*
+    """
+
 [cleanup]
     [invoke cleanup]


### PR DESCRIPTION
With this change, devcli differs between disconnect/timeout while connecting or logging into the device and timeout while doing the real stuff. So now, if the device times out because particular state causes issues, cli2netconf is able to continue; if it times out in the initial phases of the connection, cli2netconf gives up and XMNR reports a timeout/connection issue.