### PR TITLE
new setup-xmnr parameter to create default config file if needed

### DIFF
--- a/python/drned_xmnr/op/common_op.py
+++ b/python/drned_xmnr/op/common_op.py
@@ -72,7 +72,6 @@ class LoadDefaultConfigOp(ActionBase):
     def perform(self):
         result, _ = self.devcli_run('load-default-config.py', [])
         if result != 0:
-            self.log.debug("Exception: " + repr(e))
             raise ActionError('Failed to load default configuration!')
 
         if self.filter.devcli_error is None:

--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -26,6 +26,7 @@ class SetupOp(base_op.ActionBase):
     def _init_params(self, params):
         self.overwrite = params.overwrite
         self.queue = params.use_commit_queue
+        self.save_default_config = params.save_default_config
 
     def perform(self):
         # device and states directory should have been already created
@@ -77,6 +78,12 @@ class SetupOp(base_op.ActionBase):
                 msg = "Failed to copy the `drned' directory: " + ose.strerror
             raise ActionError(msg)
         self.setup_drned()
+        # store initial device config for later state traversals
+        if self.save_default_config:
+            result, _ = self.devcli_run('save-default-config.py', [])
+            if result != 0:
+                raise ActionError("Failed saving initial device configuration.")
+
         return {'success': "XMNR set up for device " + self.dev_name}
 
     def prepare_setup(self, trans):

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -188,6 +188,12 @@ module drned-xmnr {
               type boolean;
               default true;
             }
+            leaf save-default-config {
+              tailf:info "Save current on-device configuration as a new default
+                          for state traversals.";
+              type boolean;
+              default false;
+            }
           }
           output {
             uses action-output-common;


### PR DESCRIPTION
Added new parameter to `setup-xmnr` action to allow creation of drned-init file on device - saving default configuration.
Behavior 1:1 as for the `save-detault-config` action.