### PR TITLE
device renaming in DrNED done carefully for .xml files

### DIFF
--- a/drned/drned/device.py
+++ b/drned/drned/device.py
@@ -965,7 +965,10 @@ class Device(object):
                 root = etree.parse(name)
                 dev = root.xpath('//ns:device/ns:name',
                                  namespaces={'ns':'http://tail-f.com/ns/ncs'})
-                dev[0].text = self.name
+                if dev:
+                    # The configuration may be empty and would not
+                    # contain the device name
+                    dev[0].text = self.name
                 temp.write(etree.tostring(root, pretty_print=True, encoding="unicode"))
         else:
             with open(name) as n:


### PR DESCRIPTION
In 5.5 or later the state file may be empty, in particular it would not contain even the device name.  DrNED makes sure that the device name in a state file is correct, but it always assumes it is there.