### PR TITLE
better device timeout handling & testing

### DIFF
--- a/drned-skeleton/cli2netconf.py
+++ b/drned-skeleton/cli2netconf.py
@@ -78,6 +78,14 @@ def cli2netconf(nsargs):
         print()  # make sure the exception is on a new line
         print(e)
         return -1
+    except BaseException as e:
+        if e.__class__.__name__ == 'Failed':
+            # result of `pytest.fail()` call - DrNED does that if NSO
+            # or the device responds in unexpected ways
+            print()
+            print('DrNED thrown a pytest failure')
+            return -1
+        raise  # give up
     return 0
 
 

--- a/drned-skeleton/cli2netconf.py
+++ b/drned-skeleton/cli2netconf.py
@@ -84,10 +84,16 @@ def _cli2netconf(device, devcli, fnames):
             raise
         except (DevcliAuthException, DevcliDeviceException):
             raise
-        except BaseException as e:
+        except DevcliException as e:
             print('failed to convert group', groupname)
             print('exception:', e)
-        devcli.restore_config(backup_config)
+        try:
+            devcli.restore_config(backup_config)
+        except DevcliException as e:
+            # this is serious, the device is left configured somehow
+            print('failed to restore device config after group', groupname)
+            print('exception:', e)
+            raise
     sync_from(device)
 
 

--- a/drned-skeleton/cli2netconf.py
+++ b/drned-skeleton/cli2netconf.py
@@ -20,6 +20,9 @@ testrx = re.compile(r'(?P<set>[^:.]*)(?::(?P<index>[0-9]+))?(?:\..*)?$')
 SetDesc = namedtuple('SetDesc', ['fname', 'fset', 'index'])
 
 
+backup_config = 'drned-backup'
+
+
 def fname_set_descriptors(fnames):
     for fname in sorted(fnames):
         m = testrx.match(fname)
@@ -61,7 +64,7 @@ def group_cli2netconf(device, devcli, group):
         try:
             sync_from(device)
         except BaseException:
-            devcli.clean_config()
+            devcli.restore_config(backup_config)
             sync_from(device)
             raise
         save(device, target)
@@ -70,7 +73,6 @@ def group_cli2netconf(device, devcli, group):
 
 def _cli2netconf(device, devcli, fnames):
     # Save initial CLI state
-    backup_config = 'drned-backup'
     devcli.save_config(backup_config)
     namegroups = itertools.groupby(fname_set_descriptors(fnames),
                                    key=operator.attrgetter('fset'))

--- a/drned-skeleton/devcli.py
+++ b/drned-skeleton/devcli.py
@@ -161,13 +161,11 @@ class Devcli:
             raise DevcliException("Failed to get config into %s" % fname)
         return self
 
-    def restore_config(self, fname=None):
+    def restore_config(self, fname):
         """Restore configuration on the device.
 
         If `fname` is not provided, the initial configuration is used.
         """
-        if fname is None:
-            fname = self.initial_config
         self._banner(fname)
         self.data = fname
         self.interstate(["restore", "exit"])
@@ -178,13 +176,11 @@ class Devcli:
     def clean_config(self):
         """Clean all device configuration and enter initial state.
         """
-        return self.restore_config()
+        return self.restore_config(self.initial_config)
 
-    def save_config(self, fname=None):
+    def save_config(self, fname):
         """Save the initial configuration.
         """
-        if fname is None:
-            fname = self.initial_config
         self._banner(fname)
         self.data = fname
         self.interstate(["save", "exit"])

--- a/drned-skeleton/devcli.py
+++ b/drned-skeleton/devcli.py
@@ -210,6 +210,11 @@ class Devcli:
         """
         return self.restore_config(self.initial_config)
 
+    def backup_config(self):
+        """Save the device initial configuration.
+        """
+        return self.save_config(self.initial_config)
+
     def save_config(self, fname):
         """Save the initial configuration.
         """

--- a/drned-skeleton/load-default-config.py
+++ b/drned-skeleton/load-default-config.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from contextlib import closing
 import sys
 
-from devcli import Devcli, XDevice, DevcliException
+from devcli import Devcli, NcsDevice, DevcliException
 
 
 def _load_default_config(nso_device, target_device):
@@ -21,7 +21,7 @@ def load_default_config(nsargs):
         return closing(Devcli(nsargs))
 
     def init_nso_dev(devcli):
-        return closing(XDevice(devcli.devname))
+        return NcsDevice(devcli.devname)
 
     with init_cli_dev() as target_device, \
             init_nso_dev(target_device) as nso_device:

--- a/drned-skeleton/load-default-config.py
+++ b/drned-skeleton/load-default-config.py
@@ -8,7 +8,7 @@ from devcli import Devcli, XDevice, DevcliException
 
 def _load_default_config(nso_device, target_device):
     try:
-        target_device.restore_config()
+        target_device.clean_config()
         nso_device.sync_from()
     except DevcliException as e:
         print()

--- a/drned-skeleton/save-default-config.py
+++ b/drned-skeleton/save-default-config.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 
 from contextlib import closing
 
-from devcli import Devcli, XDevice
+from devcli import Devcli, NcsDevice
 
 
 def _save_default_config(nso_device, target_device):
-    target_device.save_config()
+    target_device.backup_config()
 
 
 def save_default_config(nsargs):
@@ -14,7 +14,7 @@ def save_default_config(nsargs):
         return closing(Devcli(nsargs))
 
     def init_nso_dev(devcli):
-        return closing(XDevice(devcli.devname))
+        return NcsDevice(devcli.devname)
 
     with init_cli_dev() as target_device, \
             init_nso_dev(target_device) as nso_device:

--- a/python/drned_xmnr/op/common_op.py
+++ b/python/drned_xmnr/op/common_op.py
@@ -21,6 +21,7 @@ class DevcliLogMatch(object):
         r'|(?P<match>^MATCHED \'(?P<matchstate>.*)\', SEND: .*)'
         r'|(?P<closed>device communication failure: .*EOF.*)'
         r'|(?P<timeout>device communication failure: .*Timeout.*)'
+        r'|(?P<pytestfail>DrNED thrown a pytest failure)'
         r'|(?P<authfailed>failed to authenticate)'
         r')$')
     matchrx = re.compile(matchexpr)
@@ -48,6 +49,10 @@ class DevcliLogMatch(object):
         elif match.lastgroup == 'timeout':
             self.devcli_error = 'device communication timeout'
             return 'Device communication timeout'
+        elif match.lastgroup == 'pytestfail':
+            # that can be a multitude of reasons
+            self.devcli_error = 'device communication failure'
+            return 'Device communication failure'
         elif match.lastgroup == 'authfailed':
             self.devcli_error = 'failed to authenticate'
             return 'Failed to authenticate to the device CLI'

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -349,6 +349,7 @@ class ConvertMatch(DevcliLogMatch):
         r'(?:(?P<convert>converting [^ ]* to [^ ]*/(?P<cnvstate>[^/]*)[.]xml)'
         r'|(?P<converted>converted [^ ]* to (?P<target>[^ ]*/(?P<donestate>[^/]*)[.]xml))'
         r'|(?P<failure>failed to convert group (?P<group>.*))'
+        r'|(?P<restore_failed>failed to restore device config after group (?P<rest_group>.*))'
         r'|(?P<format>Filename format not understood: (?P<filename>.*))'
         r')$')
     matchrx = re.compile(matchexpr)
@@ -376,6 +377,10 @@ class ConvertMatch(DevcliLogMatch):
             group = gd['group']
             self.failures.append(group)
             return 'failed to import group ' + group
+        elif match.lastgroup == 'restore_failed':
+            group = gd['rest_group']
+            self.failures.append(group)
+            return 'failed to restore the device config after converting ' + group
         elif match.lastgroup == 'format':
             filename = gd['filename']
             msg = 'unknown filename format: {}; should be name[:index].ext'

--- a/test/lux/etrafo/usr/device/netsim_J.py
+++ b/test/lux/etrafo/usr/device/netsim_J.py
@@ -10,6 +10,8 @@ class Devcfg(object):
     def __init__(self, path, name):
         self.path = path
         self.name = name
+        with open('/tmp/done.txt', 'a') as done:
+            print(f'start: {os.getcwd()}', file=done)
 
     def init_params(self, devname='netsim0',
                     ip='127.0.0.1', port=12022,
@@ -71,7 +73,7 @@ class Devcfg(object):
             ],
             "put-done": [
                 ("Error: (syntax error|bad value) on line", None, "failure"),
-                (self.get_prompt(), "commit", "commit"),
+                (self.get_prompt(), put_done, "commit"),
             ],
             "commit": [
                 ("Commit complete|No modifications to commit", None,
@@ -108,3 +110,12 @@ class Devcfg(object):
                 ("Connection to .* closed\\.", None, "done"),
             ],
         }
+
+
+def put_done(devcli):
+    if 'usr03' in devcli.data:
+        with open('/tmp/timeout-sync.fifo', 'a') as fifo:
+            print('commit: {}'.format(devcli.data), file=fifo)
+        with open('/tmp/timeout-sync.fifo', 'r') as fifo:
+            fifo.read()
+    return "commit"

--- a/test/lux/etrafo/usr/device/netsim_J.py
+++ b/test/lux/etrafo/usr/device/netsim_J.py
@@ -13,6 +13,7 @@ class Devcfg(object):
     def __init__(self, path, name):
         self.path = path
         self.name = name
+        self.state_file = None
         with open(syncfifo, "r") as fifo:
             self.state = fifo.read()[:-1]
 
@@ -76,7 +77,7 @@ class Devcfg(object):
             ],
             "put-done": [
                 ("Error: (syntax error|bad value) on line", None, "failure"),
-                (self.get_prompt(), self.sync("put", "commit"), "commit"),
+                (self.get_prompt(), self.put_sync, "commit"),
             ],
             "commit": [
                 ("Commit complete|No modifications to commit", None,
@@ -100,12 +101,7 @@ class Devcfg(object):
                  "restore-commit"),
             ],
             "restore-commit": [
-                (self.get_prompt(), "commit", "restore-done"),
-            ],
-            "restore-done": [
-                ("Commit complete|No modifications to commit",
-                 self.sync("restore"),
-                 "prompt-done"),
+                (self.get_prompt(), self.restore_sync, "commit"),
             ],
             # Exit
             "exit": [
@@ -119,15 +115,22 @@ class Devcfg(object):
             ],
         }
 
-    def sync(self, state, cmd=None):
-        def do_sync(devcli):
-            if 'usr03' in devcli.data:
-                with open(syncfifo, 'a') as fifo:
-                    print('commit: {}'.format(devcli.data), file=fifo)
-                with open(syncfifo, 'r') as fifo:
-                    fifo.read()
-            return cmd
+    def put_sync(self, devcli):
+        self.state_file = None
+        if "usr03" in devcli.data:
+            self.state_file = devcli.data
+            if self.state == "put":
+                self.sync(devcli)
+        return "commit"
 
-        def do_nothing(_):
-            return cmd
-        return do_sync if state == self.state else do_nothing
+    def restore_sync(self, devcli):
+        if self.state_file is not None and self.state == "restore":
+            print('syncing restore')
+            self.sync(devcli)
+        return "commit"
+
+    def sync(self, devcli):
+        with open(syncfifo, 'a') as fifo:
+            print('sync: {}'.format(self.state_file), file=fifo)
+        with open(syncfifo, 'r') as fifo:
+            fifo.read()

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -3,6 +3,7 @@
 [include common.luxinc]
 
 [global ECONFD_DIR=$$NCS_DIR/netsim/confd/erlang/econfd]
+[global fifo=/tmp/timeout-sync.fifo]
 
 [macro econfd-check]
     [local beamfile=$ECONFD_DIR/ebin/econfd.beam]
@@ -53,25 +54,47 @@
     ! -s econfd -s ec_transform -noinput
     ?ec_transform_server: Server started
 
+[macro suspend-import resume_pattern]
+[shell fifo]
+    [timeout 20]
+    !cat $fifo
+    ?commit: .*usr03
+[shell ncs-cli]
+    ?importing state usr03
+[shell netsim]
+    ~$_CTRL_Z_
+    ?Stopped
+[shell fifo]
+    !echo continue > $fifo
+[shell ncs-cli]
+    [timeout 30]
+    ?$resume_pattern
+[shell netsim]
+    !fg
+[shell ncs-cli]
+[endmacro]
+
 [macro suspend-for stop_pattern resume_pattern]
     ?$stop_pattern
 [shell netsim]
     ~$_CTRL_Z_
-
+    ?Stopped
 [shell ncs-cli]
     ?$resume_pattern
-
 [shell netsim]
     !fg
-
 [shell ncs-cli]
 [endmacro]
 
+[shell fifo]
+    !mkfifo $fifo
+    ?SH-PROMPT
 [shell ncs-cli]
+    
     [progress convert with timeout]
     [timeout 20]
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
-    [invoke suspend-for "importing state usr03" "failed to import group .*"]
+    [invoke suspend-import "failed to import group .*/usr03"]
     ?importing state usr06
     ?failure failed to convert configuration.s.: [^ ]*usr03
     [timeout]
@@ -110,9 +133,9 @@
     [progress convert with a dead device]
     !drned-xmnr state delete-state state-name-pattern *
     ?Deleted: ((usr0[1-6]|empty),? *){5}
-    [timeout 40]
+
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
-    [invoke suspend-for "importing state usr03" "Device communication (failure|timeout)"]
+    [invoke suspend-import "Device communication timeout"]
     [timeout]
     !do show devices device etrafo0 drned-xmnr state states
     """?
@@ -125,4 +148,6 @@
     """
 
 [cleanup]
+    !rm -f $fifo
+    ?SH-PROMPT
     [invoke cleanup]

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -112,7 +112,7 @@
     ?Deleted: ((usr0[1-6]|empty),? *){5}
     [timeout 40]
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
-    [invoke suspend-for "importing state usr03" "Device communication timeout"]
+    [invoke suspend-for "importing state usr03" "Device communication (failure|timeout)"]
     [timeout]
     !do show devices device etrafo0 drned-xmnr state states
     """?

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -1,4 +1,12 @@
-[doc Testing event filtering and processing for DrNED transitions]
+[doc]
+Testing event filtering and processing for DrNED transitions
+
+The test uses named pipe (mkfifo) to synchronize between the test and
+the device driver.  The synchronization makes sure that timeouts occur
+predictably.
+[enddoc]
+
+
 
 [include common.luxinc]
 
@@ -61,7 +69,7 @@
 [shell fifo]
     [timeout 20]
     !cat $fifo
-    ?commit: .*usr03
+    ?sync: .*usr03
 [shell ncs-cli]
     ?importing state usr03
 [shell netsim]
@@ -70,7 +78,7 @@
 [shell fifo]
     !echo continue > $fifo
 [shell ncs-cli]
-    [timeout 30]
+    [timeout 40]
     ?$resume_pattern
 [shell netsim]
     !fg
@@ -92,12 +100,9 @@
 [shell fifo]
     !mkfifo $fifo
     ?SH-PROMPT
-[shell ncs-cli]
-    
-    [progress convert with timeout]
-[shell fifo]
     !echo put > $fifo
 [shell ncs-cli]
+    [progress convert with timeout]
     [timeout 20]
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
     [invoke suspend-import "failed to import group .*/usr03"]
@@ -108,7 +113,6 @@
     """?
     STATE *DISABLED *
     -----* *
-    empty *- *
     usr01 *- *
     usr02 *- *
     usr04 *- *
@@ -136,12 +140,37 @@
     admin@ncs.*
     """
 
+    [progress convert with restore timeout]
+[shell fifo]
+    !echo restore > $fifo
+[shell ncs-cli]
+    !drned-xmnr state delete-state state-name-pattern *
+    ?Deleted: (usr0[1-6],? *){4}
+
+    !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
+    [invoke suspend-import "failed to restore the device config"]
+    [timeout 10]
+    ?failed to convert.*usr03
+    [timeout]
+    !do show devices device etrafo0 drned-xmnr state states
+    # usr03 has been converted, it failed while restoring initial
+    # state; usr04 should not show up
+    """?
+    STATE *DISABLED *
+    -----* *
+    usr01 *- *
+    usr02 *- *
+    usr03 *- *
+
+    admin@ncs.*
+    """
+
     [progress convert with a dead device]
 [shell fifo]
     !echo put > $fifo
 [shell ncs-cli]
     !drned-xmnr state delete-state state-name-pattern *
-    ?Deleted: (usr0[1-6],? *){4}
+    ?Deleted: (usr0[1-3],? *){3}
 
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
     [invoke suspend-import "Device communication timeout"]

--- a/test/lux/timeouts.lux
+++ b/test/lux/timeouts.lux
@@ -38,6 +38,9 @@
 [shell ncs-cli]
 
     [invoke prepare-test etrafo0]
+    # the empty state not needed
+    !drned-xmnr state delete-state state-name-pattern empty
+    ?Deleted: empty
     # remove redundant users
     !no config users user public
     !no config users user private
@@ -92,6 +95,9 @@
 [shell ncs-cli]
     
     [progress convert with timeout]
+[shell fifo]
+    !echo put > $fifo
+[shell ncs-cli]
     [timeout 20]
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
     [invoke suspend-import "failed to import group .*/usr03"]
@@ -131,8 +137,11 @@
     """
 
     [progress convert with a dead device]
+[shell fifo]
+    !echo put > $fifo
+[shell ncs-cli]
     !drned-xmnr state delete-state state-name-pattern *
-    ?Deleted: ((usr0[1-6]|empty),? *){5}
+    ?Deleted: (usr0[1-6],? *){4}
 
     !drned-xmnr state import-convert-cli-files file-path-pattern ../etrafo/usr/usr*.cfg
     [invoke suspend-import "Device communication timeout"]


### PR DESCRIPTION
The `timeouts` test was failing intermittently; one reason was a race condition in the test itself, but other reasons were also that timeout behavior was quite unpredictable, and there were actual bugs in how they were handled.
Most important changes are:
* the device driver used in the test and the test itself synchronize to prepare timeout scenarios;
* removed DrNED's `Device` from `Devcli`; the few actions for which `Device` was used are replaced by MAAPI calls;
* timeout/failure during `restore_config` is handled separately - in that case the action is aborted; added test for this scenario.