### PR TITLE
CLI output to file and/or action

### DIFF
--- a/python/log_action.py
+++ b/python/log_action.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import sys
+from argparse import ArgumentParser
+
+import ncs
+from ncs.dp import Action, Daemon
+
+
+class LogAction(Action):
+    @Action.action
+    def cb_action(self, uinfo, name, kp, input, output):
+        sys.stdout.write(f'{input.device}: {input.message}')
+
+
+if __name__ == '__main__':
+    ap = ArgumentParser()
+    ap.add_argument('-i', '--ip', type=str, default='127.0.0.1')
+    ap.add_argument('-p', '--port', type=int, default=ncs.PORT)
+    args = ap.parse_args()
+    d = Daemon(name='clilogger', ip=args.ip, port=args.port)
+    action = LogAction(daemon=d, actionpoint='xmnr-cli-log')
+    d.start()
+    print('logger started, hit <ENTER> to quit\n')
+    sys.stdin.read(1)
+    d.finish()

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -84,6 +84,15 @@ module drned-xmnr {
          from the CLI.";
       type string;
     }
+    leaf cli-log-file {
+      tailf:info
+        "If set, all output that would be printed to CLI, goes to that
+         file; if run from a CLI session, output is printed both to
+         CLI as well as to the file.  The path should be absolute
+         (otherwise the file is opened wherever xmnr happens to be
+         running).";
+      type string;
+    }
     container log-detail {
       typedef filter {
         type enumeration {

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -93,6 +93,20 @@ module drned-xmnr {
          running).";
       type string;
     }
+    tailf:action cli-log-message {
+      tailf:actionpoint xmnr-cli-log;
+      tailf:info
+        "If registered, all output that would be printed to CLI is
+         also sent to the action callback.";
+      input {
+        leaf device {
+          type string;
+        }
+        leaf message {
+          type string;
+        }
+      }
+    }
     container log-detail {
       typedef filter {
         type enumeration {


### PR DESCRIPTION
Adds two new options:
* when `/drned-xmnr/cli-log-file` is configured (with absolute path, preferably), XMNR sends to that file every line that would be sent to CLI;
* when a daemon registers `xmnr-cli-log` actionpoint, that daemon will receive action callbacks with every line that would be sent to CLI.

An example logging daemon is part of the commit:
```
xmnr$ cd python/
xmnr/python$ export PYTHONPATH=${NCS_DIR}/src/ncs/pyapi
xmnr/python$ ./log_action.py --help
usage: log_action.py [-h] [-i IP] [-p PORT]

optional arguments:
  -h, --help            show this help message and exit
  -i IP, --ip IP
  -p PORT, --port PORT
xmnr/python$ ./log_action.py
logger started, hit <ENTER> to quit

dhcp0: importing state c-cfg
dhcp0: importing state s-dlt

xmnr/python$ 
```