### PR TITLE
sync-from failure raises noncritical exception

### DIFF
--- a/drned-skeleton/cli2netconf.py
+++ b/drned-skeleton/cli2netconf.py
@@ -62,6 +62,7 @@ def _cli2netconf(device, devcli, fnames):
             print('Keyboard interrupt, abort')
             raise
         except (DevcliAuthException, DevcliDeviceException):
+            # these are critical - don't try to recover
             raise
         except DevcliException as e:
             print('failed to convert group', groupname)

--- a/drned-skeleton/devcli.py
+++ b/drned-skeleton/devcli.py
@@ -74,7 +74,7 @@ class NcsDevice:
         res = self.device.sync_from.request()
         if not res.result:
             print('sync-from failed:', res.info)
-            raise DevcliDeviceException('sync-from failed')
+            raise DevcliException('sync-from failed')
 
     def save(self, target):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sck, \


### PR DESCRIPTION
`sync-from` raised a non-recoverable exception - this has been changed.