### PR TITLE
draft parse-log-errors action

### DIFF
--- a/.github/workflows/drned-xmnr-unit.yml
+++ b/.github/workflows/drned-xmnr-unit.yml
@@ -18,7 +18,7 @@ jobs:
       XMNR_DIR: .
     strategy:
       matrix:
-        python-version: [ '3.10', '3.9', '3.8', '3.7', '3.6', '2.7' ]
+        python-version: [ '3.10', '3.9', '3.8', '3.7', '3.6' ]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ how to install these packages:
    for example in Ubuntu they can be installed like
 
         $ sudo apt install python3-pytest python3-lxml python3-pexpect
-       
+
    Note that these are packages that run with Python 3.  If you happen to be
    restricted to Python 2, install `python-pytest`, `python-lxm`, and
    `python-pexpect`.
@@ -52,26 +52,26 @@ how to install these packages:
    or for a system-wide installation
 
         $ sudo pip install -r requirements.txt
-       
+
  3. If it is required that the packages are not only user-specific but also
     project-specific, it is possible to use so called python virtual
     environments.  Using them can be greatly simplified by the tool `pipenv`
     which needs to be installed first (globally or per user):
-    
+
         $ pip install --user pipenv
-       
+
     or
 
         $ sudo pip install pipenv
-       
+
     Have a look at the file `Pipfile` - it tells `pipenv` what packages and in
     what versions need to be installed for the project environment.  The
     environment can be created with required packages using
-    
+
         $ pipenv install
-       
+
     Now, so as to enter the environment, run
-    
+
         $ pipenv shell
 
     This starts a new OS shell with paths pointing to the installed packages.
@@ -127,20 +127,20 @@ more details about the problem in case of failure).
  * **Coverage**
 
     DrNED is capable of reporting how big part of the device model your tests have
-    covered; the tool implements a simple wrapper around this DrNED capability, 
+    covered; the tool implements a simple wrapper around this DrNED capability,
     including status data providing the coverage report in a structured form.
 
 ## Debugging issues
 
-Your main tools for debugging issues are logs. 
+Your main tools for debugging issues are logs.
 
   * First you have the DrNED log that you control the filtering of via
-    `/drned-xmnr/log-detail/cli` and output via `/drned-xmnr/log-detail/redirect`. 
-    In an automated test environment, you would normally set the cli detail to 
+    `/drned-xmnr/log-detail/cli` and output via `/drned-xmnr/log-detail/redirect`.
+    In an automated test environment, you would normally set the cli detail to
     `drned-overview` to get the DrNED reports, and you would likely want to
     redirect the output to a file. When debugging issues, you may want to remove
-    the redirect to file and output everything to your CLI console with the 
-    log-detail set to `all`. 
+    the redirect to file and output everything to your CLI console with the
+    log-detail set to `all`.
   * Equally useful is the ncs-python-vm-drned-xmnr.log that you control through
     `/python-vm/logging/vm-levels/drned-xmnr/level/`. To maximize the information
     captured by this log, set to `level-debug`. The log can be found in the
@@ -149,7 +149,12 @@ Your main tools for debugging issues are logs.
     with the (virtual/physical) device. Set the `/devices/device/<my-device>/trace`
     to `pretty` or `raw` to capture the communication between the NED and the device.
   * For other issues detected and reported by NSO, refer to the NSO administration
-    guide for troubleshooting adivce. 
+    guide for troubleshooting adivce.
+  * Device specific action `parse-log-errors` below device's `drned-xmnr` node can be
+    used to parse either global drned-xmnr logfile, or device specific trace log.
+    After it's exection for a device, you can try checking the records parsed automatically
+    from the filesystem log files. Invoke the show command (device name appropriately
+    specified for your use-case): `show devices device MyDevice drned-xmnr parsed-problems`.
 
 ## Common problems
 

--- a/python/drned_xmnr/action.py
+++ b/python/drned_xmnr/action.py
@@ -48,6 +48,7 @@ class ActionHandler(dp.Action):
         ns.ns.drned_xmnr_collect_: coverage_op.CoverageOp,
         ns.ns.drned_xmnr_load_default_config_: common_op.LoadDefaultConfigOp,
         ns.ns.drned_xmnr_save_default_config_: common_op.SaveDefaultConfigOp,
+        ns.ns.drned_xmnr_parse_log_errors_: common_op.ParseLogErrorsOp,
     }
 
     def init(self):

--- a/python/drned_xmnr/common_types.py
+++ b/python/drned_xmnr/common_types.py
@@ -1,0 +1,3 @@
+from typing import Dict, Union
+
+ActionResult = Union[Dict[str, str], None]

--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -28,6 +28,14 @@ else:
     def text_data(data):
         return data
 
+
+if _ncs.LIB_VSN < 0x07060000:
+    def maapi_keyless_create(node, i):
+        return node.create(i)
+else:
+    def maapi_keyless_create(node, _i):
+        return node.create()
+
 TIMEOUT_MARGIN = 5
 '''Number of seconds between the device timeout and action timeout.
 When XMNR gets any output from a DrNED test, it extends the action

--- a/python/drned_xmnr/op/parse_log_errors.py
+++ b/python/drned_xmnr/op/parse_log_errors.py
@@ -1,0 +1,162 @@
+from drned_xmnr.namespaces.drned_xmnr_ns import ns
+
+from collections import namedtuple
+from os.path import basename
+
+from typing import Callable, List, Optional, TextIO
+
+TimeParser = Callable[[str], Optional[str]]
+
+
+def _common_time_parser(x: str) -> Optional[str]:
+    s = x.split()
+    if len(s) > 1:
+        return s[1]
+    return None
+
+
+class ProblemMatcher:
+    def __init__(self,
+                 match_start: str,
+                 match_stop: Optional[str] = None,
+                 time_parser: Optional[TimeParser] = _common_time_parser,
+                 max_lines: int = 0
+                 ) -> None:
+        self.match_start = match_start
+        self.match_stop = match_stop
+        self.time_parser = time_parser
+        self.max_lines = max_lines
+
+    def is_stop_line(self, line: str) -> bool:
+        if self.match_stop is None:
+            return False
+        return (self.match_stop in line)
+
+    def __str__(self) -> str:
+        from pprint import pformat
+        return pformat(vars(self))
+
+
+PROBLEM_MATCHERS = [
+    ProblemMatcher(match_start=" !! ", match_stop=">>>> \"exit\" >>>>", max_lines=16),
+    ProblemMatcher(match_start="E  "),
+    ProblemMatcher(match_start="sync-from failed:"),
+    ProblemMatcher(match_start="Aborted: RPC error"),
+]
+
+
+def _get_matcher(line: str) -> Optional[ProblemMatcher]:
+    for m in PROBLEM_MATCHERS:
+        if m.match_start in line:
+            return m
+    return None
+
+
+TestCase = namedtuple('TestCase', ['phase', 'name'])
+
+
+class ProblemData:
+    """ All the data describing single instance of problem
+        parsed from the log lines. """
+    def __init__(self, line_num: int, test_case: Optional[TestCase]) -> None:
+        self.line_num = line_num
+        self.phase = None if test_case is None else test_case.phase
+        self.test_case = "----unknown----" if test_case is None else str(test_case.name)
+        self.time: Optional[str] = None
+        self.lines: List[str] = []
+
+
+def parse_test_case(line: str) -> Optional[TestCase]:
+    pattern = " converting "
+    if pattern in line:
+        return TestCase(phase=ns.drned_xmnr_conversion_, name=basename(_strip_pattern(pattern, line).split()[0]))
+
+    pattern = "py.test -k"
+    if pattern in line:
+        sub_pattern = "test_template_set"
+        if sub_pattern in line:
+            fname = basename(_strip_pattern("--fname=", line).split()[0])
+            return TestCase(phase=ns.drned_xmnr_test_, name=fname)
+        return TestCase(phase=ns.drned_xmnr_test_, name=basename(_strip_pattern(pattern, line).split()[0]))
+
+    return None
+
+
+class PendingData:
+    """ Keeps track of pending multi-line structure of file,
+        last observed test-case id, problem, etc. """
+    def __init__(self) -> None:
+        self.test_case: Optional[TestCase] = None
+        self.matcher: Optional[ProblemMatcher] = None
+        self.problem: Optional[ProblemData] = None
+
+    def update_problem(self, line: str, pending: bool = False) -> None:
+        """ Add the input line to pending problem data. """
+        if self.matcher is None or self.problem is None:
+            return
+        time_parser = self.matcher.time_parser
+        self.problem.time = None if time_parser is None else time_parser(line)
+        pattern = ' - '  # if pending else self.matcher.match_start
+        self.problem.lines.append(_strip_pattern(pattern, line))
+        if self.matcher.max_lines > 0 and len(self.problem.lines) > self.matcher.max_lines:
+            del self.problem.lines[0]
+
+
+# logger: List[str],
+def gather_problems(file: TextIO) -> List[ProblemData]:
+    """ Read through the input file and collect data for all the idetified
+        problems found inside. """
+    problems: List[ProblemData] = []
+
+    pending = PendingData()
+
+    for line_num, line in enumerate(file):
+        test_case = parse_test_case(line)
+        # new test-case opening
+        if test_case is not None:
+            if pending.problem is not None:
+                problems.append(pending.problem)
+                pending.problem = None
+            pending.test_case = test_case
+            # logger.append("---- new test-case: line %d: %s" % (line_num + 1, test_case))
+            continue
+
+        # potential start of new problem
+        if pending.matcher is None:
+            pending.matcher = _get_matcher(line)
+            if pending.matcher is None:
+                # no new problem for this log file line
+                continue
+            pending.problem = ProblemData(line_num + 1, pending.test_case)
+            pending.update_problem(line)
+            # logger.append("---- new problem on line: %d" % (line_num))
+            continue
+
+        # pending matcher with end pattern
+        if pending.matcher.match_stop is not None:
+            if pending.matcher.is_stop_line(line):
+                if pending.problem is not None:
+                    problems.append(pending.problem)
+                    pending.problem = None
+                pending.matcher = None
+            else:
+                pending.update_problem(line, pending=True)
+            continue
+
+        # pending exact matcher (no end pattern)
+        if pending.matcher.match_start in line:
+            pending.update_problem(line)
+        # shorctut - two different matches cannot run in sequence with no separation
+        else:
+            problems.append(pending.problem)
+            pending.problem = None
+            pending.matcher = None
+        # logger.append("---- normal line: %s" % (line))
+
+    return problems
+
+
+def _strip_pattern(pattern: str, line: str) -> str:
+    pat_index = line.find(pattern)
+    pat_len = len(pattern)
+    return line[(pat_index + pat_len):]

--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -14,14 +14,6 @@ from . import base_op
 from . import filtering
 
 
-if _ncs.LIB_VSN < 0x07060000:
-    def keyless_create(node, i):
-        return node.create(i)
-else:
-    def keyless_create(node, _i):
-        return node.create()
-
-
 class TransitionsOp(base_op.ActionBase):
     def perform(self):
         '''Performs the transition action and process DrNED output.
@@ -115,7 +107,7 @@ class TransitionsOp(base_op.ActionBase):
         results.device = self.dev_name
         results.transition.delete()
         for i, event in enumerate(self.event_context.test_events):
-            tsinst = keyless_create(results.transition, i)
+            tsinst = base_op.maapi_keyless_create(results.transition, i)
             tsinst['from'] = event.start
             tsinst.to = event.to
             if event.failure is not None:

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -546,6 +546,80 @@ module drned-xmnr {
           }
         }
       }
+
+      typedef target-log-type {
+        type enumeration {
+          enum device-trace {
+            tailf:info "Parse device specfic problems only";
+          }
+          enum common-xmnr-log {
+            tailf:info "Parse all problems from common XMNR log";
+          }
+        }
+      }
+
+      container parsed-problems {
+        config false;
+        tailf:cli-show-template
+            "$(target-log?Parsed log $(target-log),)"
+          + "$(target-log?:No log parsed - run device's action: drned-xmnr parse-log-errors.)"
+          + "$(parse-time? on $(parse-time),)"
+          + "$(count? $(count) problem/s found.)\n";
+        leaf target-log {
+          type target-log-type;
+        }
+        leaf parse-time {
+          type string;
+        }
+        leaf count {
+          type uint32;
+        }
+        list problems {
+          tailf:cli-suppress-mode;
+          tailf:cli-suppress-table;
+          tailf:cli-show-template-enter "";
+          tailf:cli-show-template-legend
+              'Line     Test-Case                                                   '
+            + '$(.selected~=phase?Phase       )'
+            + '$(.selected~=time?Time)\n'
+            + '======================================================================'
+            + '$(.selected~=phase?============)'
+            +'$(.selected~=time?========================)\n';
+
+          tailf:cli-show-template
+              '$(log-line-number|ljust:9)'
+            + '$(test-case|ljust:60)'
+            + '$(.selected~=phase?$(phase|ljust:12))'
+            + '$(.selected~=time?$(time))\n';
+          key 'log-line-number';
+          leaf log-line-number {
+            type uint32;
+          }
+          leaf test-case {
+            type string;
+          }
+          leaf phase {
+            type enumeration {
+              enum conversion;
+              enum test;
+            }
+          }
+          leaf time {
+            type string;
+            default "N/A";
+          }
+          list message-lines {
+            tailf:cli-suppress-table;
+            tailf:cli-suppress-mode;
+            tailf:cli-show-template-enter "";
+            tailf:cli-show-template
+              '$(line)\n';
+            leaf line {
+              type string;
+            }
+          }
+        }
+      }
       tailf:action load-default-config {
         tailf:info
           "Reset device to the default state by loading a previously stored
@@ -558,6 +632,19 @@ module drned-xmnr {
       tailf:action save-default-config {
         tailf:info "Save the device's running configuration as a default.";
         tailf:actionpoint drned-xmnr;
+        output {
+          uses action-output-common;
+        }
+      }
+      tailf:action parse-log-errors {
+        tailf:info "Shows problems present in XMNR related log files.";
+        tailf:actionpoint drned-xmnr;
+        input {
+          leaf target-log {
+            mandatory true;
+            type target-log-type;
+          }
+        }
         output {
           uses action-output-common;
         }


### PR DESCRIPTION
without show template for now, and possibly broken device specific log finding...

assuming we have some device DDD running, following commands can be executed in CLI to try to parse and show problems form the common XMNR log.
Any `parse-log-errors` action invocation overwrites/deletes any previously parsed problems form the target `parsed-problems` table...


```
config
devices device DDD
drned-xmnr parse-log-errors target-log common-xmnr-log
do show devices device DDD drned-xmnr parsed-problems 
```

