### PR TITLE
Python 2 no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ package. Using the tool's actions you can:
 
 ## Prerequisites
 
-The tool is supported to run on Python 3.6 or newer.  It is known to run on
-Python 2.7, but this is no longer actively maintained.
+The tool is supported to run on Python 3.6 or newer.
 
 Apart form that, several Python packages are needed: `pytest`, `pexpect`, and
 `lxml`; `pytest` version needs to be at least 3.0.  There are several options

--- a/drned-skeleton/devcli.py
+++ b/drned-skeleton/devcli.py
@@ -21,23 +21,6 @@ VERBOSE = True
 INDENT = "=" * 30 + " "
 
 
-if sys.version_info > (3, 0):
-    pexpect_args = dict(encoding='utf-8')
-    os_makedirs = os.makedirs
-else:
-    pexpect_args = {}
-
-    def os_makedirs(dirname, exist_ok=False):
-        """
-        In Python 2.7 the argument exist_ok is not available for os.makedirs.
-        """
-        try:
-            os.makedirs(dirname)
-        except OSError:
-            if not exist_ok:
-                raise
-
-
 class DevcliException(Exception):
     def __str__(self):
         return 'devcli exception: ' + str(self.args[0])
@@ -154,7 +137,7 @@ class Devcli:
         for _ in range(3):
             try:
                 self.cli = pexpect.spawn(self.ssh, timeout=self.timeout,
-                                         logfile=sys.stdout, **pexpect_args)
+                                         logfile=sys.stdout, encoding='utf-8')
                 self.interstate_one("enter")
             except DevcliAuthException:
                 # no reason to retry
@@ -280,6 +263,6 @@ def devcli_init_dirs(workdir):
     """ Initialize directories needed by DrNED device.
     Returns working directory.
     """
-    os_makedirs('drned-work', exist_ok=True)
-    os_makedirs(workdir, exist_ok=True)
+    os.makedirs('drned-work', exist_ok=True)
+    os.makedirs(workdir, exist_ok=True)
     return workdir

--- a/python/drned_xmnr/action.py
+++ b/python/drned_xmnr/action.py
@@ -18,7 +18,7 @@ from drned_xmnr.op import coverage_op
 from drned_xmnr.op import common_op
 from drned_xmnr.op.ex import ActionError
 
-assert sys.version_info >= (2, 7)
+assert sys.version_info >= (3, 6)
 # Not tested with anything lower
 
 

--- a/python/drned_xmnr/check_action.py
+++ b/python/drned_xmnr/check_action.py
@@ -4,10 +4,6 @@ import importlib
 
 from ncs import application
 
-if sys.version_info < (3, 0):
-    FileNotFoundError = IOError
-    ModuleNotFoundError = ImportError
-
 REQ_GE = '>='
 
 REQ_DEFAULTS = [
@@ -26,9 +22,8 @@ def parse_version(verstr):
 
 class XmnrCheck(application.Application):
     def setup(self):
-        if sys.version_info < (2, 7) or \
-           sys.version_info >= (3, 0) and sys.version_info < (3, 6):
-            raise XmnrCheckException('Required Python 2.7 or 3.6 or newer')
+        if sys.version_info < (3, 6):
+            raise XmnrCheckException('Required Python 3.6 or newer')
         for (package, version) in self.xmnr_requirements():
             try:
                 mod = importlib.import_module(package)

--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -23,14 +23,6 @@ from drned_xmnr.namespaces.drned_xmnr_ns import ns
 from .ex import ActionError
 
 
-if sys.version_info >= (3, 0):
-    def text_data(data):
-        return data.decode()
-else:
-    def text_data(data):
-        return data
-
-
 if _ncs.LIB_VSN < 0x07060000:
     def maapi_keyless_create(node, i):
         return node.create(i)
@@ -290,7 +282,7 @@ class ActionBase(XmnrBase):
             if rlist:
                 buf = self.drned_process.stdout.read()
                 if buf is not None and len(buf) != 0:
-                    data = text_data(buf)
+                    data = buf.decode()
                     self.log.debug("run_outputfun, output len=" + str(len(data)))
                     outputfun(data)
                     self.extend_timeout()
@@ -367,7 +359,7 @@ class ActionBase(XmnrBase):
         return ActionBase._pytest_executable
 
     def find_pytest_executable(self):
-        suffix = str(sys.version_info[0])  # '2' or '3'
+        suffix = str(sys.version_info[0])  # '3', most likely
         execs = ['pytest', 'py.test', 'pytest-' + suffix, 'py.test-' + suffix]
         for executable in execs:
             if self.check_which(executable):

--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import os
-import sys
+import re
 import shutil
 import errno
 import subprocess
@@ -12,14 +12,6 @@ from ncs import maagic
 
 from . import base_op
 from .ex import ActionError
-
-if sys.version_info >= (3, 3):
-    import functools
-    et_tostring = functools.partial(etree.tostring, encoding='unicode')
-else:
-    et_tostring = etree.tostring
-
-import re
 
 
 class DevcliLogMatch(object):
@@ -207,4 +199,4 @@ class SetupOp(base_op.ActionBase):
         for name in ['ssh', 'connect-timeout', 'read-timeout', 'trace', 'config']:
             del_element(dev, name)
         with open(self.cfg_file, 'w') as cfg:
-            cfg.write(et_tostring(devices))
+            cfg.write(etree.tostring(devices, encoding='unicode'))

--- a/test/unit/mocklib.py
+++ b/test/unit/mocklib.py
@@ -6,10 +6,7 @@ import sys
 from contextlib import contextmanager
 import functools
 from pyfakefs import fake_filesystem_unittest as ffs
-if sys.version_info >= (3, 3):
-    import unittest.mock as mock
-else:
-    import mock
+from unittest import mock
 
 patch = mock.patch
 Mock = mock.Mock

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -13,12 +13,6 @@ import functools
 import itertools
 import _ncs
 
-if sys.version_info >= (3, 0):
-    def bytestream(data):
-        return data.encode()
-else:
-    def bytestream(data):
-        return data
 
 device_data = '''\
     <config xmlns="http://tail-f.com/ns/config/1.0">
@@ -655,7 +649,7 @@ class TestConvertMessage(TestBase):
                 data.append('Filename format not understood: ' + path)
             else:
                 data.append('converting {}.cfg to {}'.format(state, path))
-        self.system.proc_data(b''.join(bytestream(line + '\n') for line in data))
+        self.system.proc_data(b''.join((line + '\n').encode() for line in data))
         return mock.DEFAULT
 
     def setup_and_start(self, xpatch, **setup_args):
@@ -975,8 +969,8 @@ class DrnedOutput(object):
         self.popen_mock.side_effect = self.popen_effect
 
     def popen_effect(self, *args, **kwargs):
-        next_data = next(self.output_iter)
-        self.system.proc_data(bytestream(next_data))
+        next_data = next(self.output_iter).encode()
+        self.system.proc_data(next_data)
         if self.failure:
             self.failure = False
             self.popen_mock.return_value.wait = mock.Mock(return_value=-1)
@@ -1267,7 +1261,7 @@ class TestCoverage(TestBase):
             collect_dict[group] = {}
             for entry in entries:
                 collect_dict[group][entry] = self.line_entry(randint(0, 1000), randint(0, 100))
-        xpatch.system.proc_data(bytestream(drned_collect_output.format(**collect_dict)))
+        xpatch.system.proc_data(drned_collect_output.format(**collect_dict).encode())
         output = self.invoke_action('collect', yang_patterns=['pat1', 'pat2'])
         self.check_output(output)
         log = mock.Mock()

--- a/test/unit/test_check.py
+++ b/test/unit/test_check.py
@@ -1,11 +1,6 @@
 from pytest import fixture, raises
 from drned_xmnr.check_action import XmnrCheck, XmnrCheckException
-import sys
-if sys.version_info < (3, 0):
-    from mock import patch
-    ModuleNotFoundError = ImportError
-else:
-    from unittest.mock import patch
+from unittest.mock import patch
 
 
 @fixture
@@ -43,7 +38,7 @@ def old_package():
 
 class TestChecks:
     def test_version_check(self, bad_py_version):
-        with raises(XmnrCheckException, match='Required Python 2.7 or 3.6 or newer'):
+        with raises(XmnrCheckException, match='Required Python 3.6 or newer'):
             XmnrCheck().setup()
 
     def test_missing_package_check(self, missing_package):

--- a/test/unit/test_cli2netconf.py
+++ b/test/unit/test_cli2netconf.py
@@ -3,7 +3,7 @@ import collections
 from contextlib import closing
 import os
 import random
-from six import functools
+import functools
 import sys
 
 from .mocklib import patch, mock
@@ -98,11 +98,10 @@ class ConvertPatch(object):
         @functools.wraps(fun)
         def _wrapper(self_arg):
             # we need to capture output from the module functions
-            print_ref = '__builtin__.print' if sys.version_info < (3,) else 'builtins.print'
             with patch.dict('os.environ', NC_WORKDIR='/'), \
                     patch('cli2netconf.Devcli', new=self.devclimock_instance), \
                     patch('cli2netconf.NcsDevice', new=self.ncsdev_instance), \
-                    patch(print_ref, new=self.print_cap):
+                    patch('builtins.print', new=self.print_cap):
                 return fun(self_arg, self)
 
         return _wrapper

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -15,7 +15,7 @@ two filtering modes.
 from __future__ import print_function
 
 import os
-import six
+import io
 
 from drned_xmnr.op import filtering
 from drned_xmnr.op.filtering.states import TransitionDesc # noqa
@@ -37,7 +37,7 @@ class FilteringTest(object):
             events = eval(data.read())
         for level, ext in [('overview', self.log_overview_ext),
                            ('drned-overview', self.log_dred_ext)]:
-            out = six.StringIO()
+            out = io.StringIO()
             ctx = filtering.run_test_filter(self.filter, logfile, out=out, level=level)
             with open(logbase + ext) as res:
                 assert out.getvalue() == res.read()

--- a/test/unit/tox.ini
+++ b/test/unit/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py38, py39, py310
+envlist = py36, py38, py39, py310
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
With recent changes and with type annotations on the way, we no longer support Python 2 - removing all `sys.version_info` checks and related stuff.