### PR TITLE
prerequisites checked in both application components

### DIFF
--- a/package-meta-data.xml
+++ b/package-meta-data.xml
@@ -4,12 +4,6 @@
   <description>DrNED Examiner is a tool for examining/diagnosing your NEDs</description>
   <ncs-min-version>4.1</ncs-min-version>
   <component>
-    <name>drned_xmnr_check</name>
-    <application>
-      <python-class-name>drned_xmnr.check_action.XmnrCheck</python-class-name>
-    </application>
-  </component>
-  <component>
     <name>drned_xmnr</name>
     <application>
       <python-class-name>drned_xmnr.action.Xmnr</python-class-name>

--- a/python/drned_xmnr/action.py
+++ b/python/drned_xmnr/action.py
@@ -9,6 +9,7 @@ import traceback
 import _ncs
 from ncs import dp, application, experimental
 import drned_xmnr.namespaces.drned_xmnr_ns as ns
+from drned_xmnr import check_action  # noqa
 
 # operation modules
 from drned_xmnr.op import config_op
@@ -159,7 +160,6 @@ class XmnrDataHandler(object):
 # ---------------------------------------------
 
 class Xmnr(application.Application):
-
     def setup(self):
         self.register_action(ns.ns.actionpoint_drned_xmnr, ActionHandler)
         self.register_action('drned-xmnr-completion', CompletionHandler)

--- a/python/drned_xmnr/check_action.py
+++ b/python/drned_xmnr/check_action.py
@@ -2,8 +2,6 @@ import os
 import sys
 import importlib
 
-from ncs import application
-
 REQ_GE = '>='
 
 REQ_DEFAULTS = [
@@ -20,39 +18,49 @@ def parse_version(verstr):
     return [int(vnum) for vnum in verstr.split('.')]
 
 
-class XmnrCheck(application.Application):
-    def setup(self):
-        if sys.version_info < (3, 6):
-            raise XmnrCheckException('Required Python 3.6 or newer')
-        for (package, version) in self.xmnr_requirements():
-            try:
-                mod = importlib.import_module(package)
-            except ModuleNotFoundError:
-                if package == 'pyang':
-                    self.log.warning('running without pyang')
-                else:
-                    errmsg = 'XMNR cannot run without the package {}'.format(package)
-                    raise XmnrCheckException(errmsg)
-            if version is not None:
-                imported_version = parse_version(mod.__version__)
-                if imported_version < version:
-                    version_str = '.'.join(map(str, version))
-                    raise XmnrCheckException('Required {}>={}'.format(package, version_str))
-
-    def xmnr_requirements(self):
-        base = os.path.realpath(os.path.dirname(__file__))
-        pkg_path = os.path.dirname(os.path.dirname(base))
+def check(log=None):
+    if sys.version_info < (3, 6):
+        raise XmnrCheckException('Required Python 3.6 or newer')
+    for (package, version) in xmnr_requirements(log):
         try:
-            with open(os.path.join(pkg_path, 'requirements.txt')) as reqs:
-                for req_line in reqs:
-                    req = req_line[:-1]
-                    # only REQ_GE supported
-                    if REQ_GE in req:
-                        [pkg, verstr] = req.split(REQ_GE)
-                        yield pkg, parse_version(verstr)
-                    else:
-                        yield req, None
-        except FileNotFoundError:
-            self.log.info('no requirements file found at {}, using defaults'.format(base))
-            for p in REQ_DEFAULTS:
-                yield p
+            mod = importlib.import_module(package)
+        except ModuleNotFoundError as ex:
+            if package == 'pyang':
+                if log is not None:
+                    log.warning('running without pyang')
+            else:
+                errmsg = 'XMNR cannot run without the package {}'.format(package)
+                raise XmnrCheckException(errmsg) from ex
+        if version is not None:
+            imported_version = parse_version(mod.__version__)
+            if imported_version < version:
+                version_str = '.'.join(map(str, version))
+                raise XmnrCheckException('Required {}>={}'.format(package, version_str))
+            if log is not None:
+                log.debug('using package {} ({})'.format(package, imported_version))
+        else:
+            if log is not None:
+                log.debug('using package {}'.format(package))
+
+
+def xmnr_requirements(log):
+    base = os.path.realpath(os.path.dirname(__file__))
+    pkg_path = os.path.dirname(os.path.dirname(base))
+    try:
+        with open(os.path.join(pkg_path, 'requirements.txt')) as reqs:
+            for req_line in reqs:
+                req = req_line[:-1]
+                # only REQ_GE supported
+                if REQ_GE in req:
+                    [pkg, verstr] = req.split(REQ_GE)
+                    yield pkg, parse_version(verstr)
+                else:
+                    yield req, None
+    except FileNotFoundError:
+        if log is not None:
+            log.info('no requirements file found at {}, using defaults'.format(base))
+        for p in REQ_DEFAULTS:
+            yield p
+
+
+check()


### PR DESCRIPTION
The old code used two NSO components, `drned_xmnr` and `drned_xmnr_check`. The latter one did nothing but to check in its setup time whether all needed packages are installed and failed with a nice error message otherwise. This solved the problem that
* in some cases XMNR failed to setup with somewhat cryptic messages ("ModuleNotFoundError")
* in other cases it initialized fine, but failed later when the user invoked action that needed those missing packages.

The problem with this solution was that the error message might not be noticed, e.g. when you start NSO with `--with-package-reload`, you would have to go to the log file to see it; and XMNR might appear to work until you run the action that needs a missing package. While there is no immediate fix for the hidden error message, this change at least makes XMNR to fail immediately and no XMNR action will succeed.

The second component has been removed and its prerequisites checking code is run in import time; this makes it possible to avoid that cryptic error messages, but obviously somewhat complicates testing - hence the changes in `test_check` module.