### PR TITLE
changed record and import format options and defaults

### DIFF
--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -48,10 +48,14 @@ module drned-xmnr {
   }
   typedef state-file-format {
     type enumeration {
-      enum xml;
-      enum c-style;
+      enum nso-xml {
+        tailf:code-name state-nso-xml;
+      }
+      enum nso-c-style {
+        tailf:code-name state-nso-c;
+      }
     }
-    default xml;
+    default nso-xml;
   }
 
   container drned-xmnr {
@@ -373,7 +377,7 @@ module drned-xmnr {
                 enum nso-xml;
                 enum nso-c-style;
               }
-              default xml;
+              default nso-xml;
             }
             leaf target-format {
               type state-file-format;

--- a/test/lux/basic.lux
+++ b/test/lux/basic.lux
@@ -52,12 +52,12 @@
     !config dhcp default-lease-time 200s
     !commit
     ???Commit complete.
-    !drned-xmnr state record-state state-name time format c-style overwrite true
+    !drned-xmnr state record-state state-name time format nso-c-style overwrite true
     ???success
     !drned-xmnr state record-state state-name time
     ???failure state time already exists
     ~drned-xmnr state import-state-files
-    ! file-path-pattern ../subnet.xml merge false overwrite true
+    ! file-path-pattern ../subnet.xml merge false overwrite true format xml
     ???success
     ~drned-xmnr state import-state-files
     ! file-path-pattern ../dhcp-ls.cfg format nso-c-style merge false overwrite true


### PR DESCRIPTION
The record formats are now both `nso-*` so that the name is consistent with the import format; and the import default format is `nso-xml`.

Note that this change may break some scripts.