### PR TITLE
coverage collect is able to work with NED modules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ more details about the problem in case of failure).
 
             ncs(config-device-testdev)# drned-xmnr coverage collect
 
+      Note that in this short form the tool looks up the NED package and uses
+      all its YANG modules.  This may take long and yield very low coverage
+      percentage.  If only a subset of YANG modules is relevant for the
+      coverage test, use a path pattern (or patterns) with wildcards pointing
+      to the interesting files like this:
+
+              ... coverage collect yang-patterns [ <pattern1> <pattern2> ... ]
+
     * inspect collected coverage data:
 
             ncs(config-device-testdev)# do show devices device testdev drned-xmnr coverage

--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -146,16 +146,6 @@ class SetupOp(base_op.ActionBase):
         self.drned_skeleton = os.path.join(xmnr_pkg, 'drned-skeleton')
         self.drned_submod = os.path.join(xmnr_pkg, 'drned')
 
-    def find_ned_package(self, root: Node, ned_id: str, ned_type: str) -> Node:
-        for package in root.packages.package:
-            for component in package.component:
-                try:
-                    if getattr(component.ned, ned_type).ned_id == ned_id:
-                        return package
-                except AttributeError:
-                    continue
-        return None
-
     def setup_drned(self) -> None:
         env = self.run_with_trans(self.setup_drned_env)
         self.drned_process = subprocess.Popen(['make', 'env.sh'],

--- a/test/unit/mocklib.py
+++ b/test/unit/mocklib.py
@@ -70,6 +70,7 @@ XMNR_DIRECTORY = 'test_xmnr_dir'
 DRNED_DIRECTORY = 'drned_dir'
 DEVICE_NAME = 'mock-device'
 XMNR_INSTALL = 'xmnr-install'
+MOCK_NED_ID = 'id:mock-id-1.0'
 
 
 class TransMgr(object):
@@ -98,7 +99,7 @@ def mock_path(path, value):
 @contextmanager
 def ncs_mock():
     nonex = Mock(exists=lambda: False)
-    device = Mock(device_type=Mock(ne_type='netconf', netconf='netconf'),
+    device = Mock(device_type=Mock(ne_type='netconf', netconf=Mock(ned_id=MOCK_NED_ID)),
                   read_timeout=None, address='1.2.3.4', port='5555', authgroup='default')
     authgrp = Mock(default_map=Mock(remote_name='admin', remote_password='admin',
                                     same_name=nonex, same_pass=nonex),


### PR DESCRIPTION
`coverage collect`, if not provided with a list of YANG patterns, now tries to look up the NED package and use its modules. Also, the feature description has been extended.