### PR TITLE
do not use "print" when writing to file

### DIFF
--- a/python/drned_xmnr/op/setup_op.py
+++ b/python/drned_xmnr/op/setup_op.py
@@ -87,7 +87,7 @@ class SetupOp(base_op.ActionBase):
                                    'package-meta-data.xml'),
                       'w') as meta:
                 if not self.queue:
-                    print('<requires-transaction-states/>', file=meta)
+                    meta.write('<requires-transaction-states/>\n')
         except OSError as ose:
             msg = "Failed to set up package-meta-data file {0}".format(os.strerror(ose.errno))
             raise ActionError(msg)


### PR DESCRIPTION
The `print` function does not work on NSO 6.0; presumably it has been redefined in its VM.